### PR TITLE
feat: add filter mode to log drawer search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 - 🔧 Others
 - 💥 Breaking
 
+## TBD
+
+- 🚀 Added **filter mode** to the search bar, to only display rows that match your search
+- ✨ Processes can now be started/stopped from the log drawer header
+- 🔧 Added setup for ClaudeCode
+
 ## 1.4.2 - 2026-01-06
 
 - 🔧 Upgraded dependencies.

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 # TODO
 
-- Allow filtering logs using the search bar
 - Allow filtering with regex

--- a/src/features/dashboard/components/ProcessLogDrawer.tsx
+++ b/src/features/dashboard/components/ProcessLogDrawer.tsx
@@ -427,18 +427,7 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
                 />
               </label>
             </div>
-            <label class="flex items-center gap-2 cursor-pointer text-xs whitespace-nowrap">
-              <input
-                type="checkbox"
-                class="toggle toggle-xs toggle-primary"
-                checked={isFilterMode()}
-                onChange={(e) =>
-                  setIsFilterMode((e.target as HTMLInputElement).checked)
-                }
-              />
-              Filter mode
-            </label>
-            <div class="flex items-center gap-1 w-25 justify-end md:justify-start">
+            <div class="flex items-center gap-1 w-18 justify-end md:justify-start">
               <Show
                 when={searchState.term}
                 fallback={<span class="text-sm text-gray-500">No search</span>}
@@ -486,6 +475,17 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
                 </Show>
               </Show>
             </div>
+            <label class="flex items-center gap-2 cursor-pointer text-xs whitespace-nowrap">
+              <input
+                type="checkbox"
+                class="toggle toggle-xs toggle-primary"
+                checked={isFilterMode()}
+                onChange={(e) =>
+                  setIsFilterMode((e.target as HTMLInputElement).checked)
+                }
+              />
+              Filter mode
+            </label>
           </div>
 
           {/* Options */}


### PR DESCRIPTION
Add a toggle switch to enable filter mode in the log drawer. In filter mode,
only logs matching the search term are displayed, while search mode continues
to show all logs with highlighted matches and navigation controls.

Changes:
- Add filter mode toggle switch in search UI
- Filter displayed logs based on mode
- Hide navigation controls in filter mode
- Update placeholder text based on mode
- Show match count in filter mode instead of navigation
- Disable Enter/Shift+Enter navigation in filter mode