### PR TITLE
feat: add play/pause button to LogDrawer header

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 # TODO
 
-- Add play/stop in the log drawer header
 - Allow filtering logs using the search bar
 - Allow filtering with regex

--- a/src/features/dashboard/components/ProcessLogDrawer.tsx
+++ b/src/features/dashboard/components/ProcessLogDrawer.tsx
@@ -14,6 +14,7 @@ import type { ProcessLogData } from "@/electron/types";
 import { isLiveUpdate } from "@/utils/ansiToHtml";
 import { useDashboardContext } from "../contexts";
 import { ProcessStatus } from "../enums";
+import { PlayStopButton } from "./PlayStopButton";
 import { ProcessLogRow } from "./ProcessLogRow";
 
 type ProcessLogDrawerProps = {
@@ -378,6 +379,7 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
               <ArrowLeft size={20} />
             </button>
             <h3 class="font-bold m-0!">Logs - {props.processName}</h3>
+            <PlayStopButton processName={props.processName} />
             <Show
               when={isRunning()}
               fallback={<div class="badge badge-neutral">Idle</div>}


### PR DESCRIPTION
Add PlayStopButton component to the ProcessLogDrawer header, allowing users to start/stop processes directly from the log view without having to close the drawer.