### PR TITLE
feat: add process auto-restart with crashed status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 - 🔧 Others
 - 💥 Breaking
 
+## TBD
+
+- 🚀 Added **process auto-restart** feature:
+  - New `restart` YAML configuration option to configure auto-restart behavior.
+  - Visual indicators for restarting processes showing retry progress (e.g., "Restarting (1/3)").
+  - Ability to cancel auto-restart by manually stopping a restarting process.
+  - See [README.md](README.md) for more information.
+- 🚀 Added **crashed status** to distinguish between manually stopped and crashed processes.
+- ✨ Added toast notifications when a process crashes.
+
 ## 1.5.0 - 2026-01-24
 
 - 🚀 Added **filter mode** to the search bar, to only display rows that match your search.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   - [⚙️ Configuration](#️-configuration)
     - [Root Configuration](#root-configuration)
     - [Process Configuration](#process-configuration)
+    - [Restart Configuration](#restart-configuration)
     - [Argument Configuration (All Types)](#argument-configuration-all-types)
     - [Toggle-Specific Configuration](#toggle-specific-configuration)
     - [Select-Specific Configuration](#select-specific-configuration)
@@ -50,6 +51,7 @@
 - **Flexible configuration**: YAML-based setup with customizable arguments
 - **Process monitoring**: Real-time status, logs, and runtime tracking
 - **Argument types**: Toggle switches, dropdowns, and text inputs
+- **Auto-restart**: Automatically restart crashed processes with configurable retry limits
 
 | Homepage | Dashboard | Log Drawer |
 | --- | --- | --- |
@@ -99,7 +101,26 @@ Create a `config.yml` file in your project directory to define your development 
 |-----------|------|----------|-------------|---------|
 | `processes[].name` | `string` | ✅ | Display name for the process | `"Web Server"` |
 | `processes[].base_command` | `string` | ✅ | Base command to execute | `"npm start"` |
+| `processes[].restart` | `object` | ❌ | Auto-restart configuration | See restart config below |
 | `processes[].args` | `array` | ❌ | List of configurable arguments | See argument types below |
+
+### Restart Configuration
+
+Configure automatic restart behavior for processes that crash unexpectedly.
+
+| YAML Path | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `restart.enabled` | `boolean` | ✅ | - | Enable/disable auto-restart |
+| `restart.max_retries` | `number` | ❌ | `3` | Max consecutive restart attempts before giving up |
+| `restart.delay_ms` | `number` | ❌ | `1000` | Delay in milliseconds before restarting |
+| `restart.reset_after_ms` | `number` | ❌ | `30000` | Reset retry counter if process runs longer than this |
+
+**Behavior:**
+
+- Processes that exit with code `0` (clean exit) are not restarted
+- Manually stopped processes are not restarted
+- The retry counter resets if the process runs successfully for longer than `reset_after_ms`
+- When max retries are exceeded, the process shows a "Crashed" status
 
 ### Argument Configuration (All Types)
 
@@ -139,6 +160,11 @@ project_name: "Development Services"
 processes:
   - name: "Web Server"
     base_command: "pnpm start"
+    restart:
+      enabled: true
+      max_retries: 3
+      delay_ms: 1000
+      reset_after_ms: 30000
     args:
       - type: "toggle"
         name: "Arg1"
@@ -171,7 +197,10 @@ processes:
         output_prefix: ""
 ```
 
-**Note**: For input arguments, set `output_prefix: ""` if you want the raw value without any prefix.
+**Notes**:
+
+- For input arguments, set `output_prefix: ""` if you want the raw value without any prefix.
+- The `restart` configuration is optional. Processes without it will show "Crashed" status on non-zero exit.
 
 ## 🚀 Usage
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -179,9 +179,12 @@ app.whenReady().then(() => {
   );
 
   // IPC handler for starting a process
-  ipcMain.handle("process:start", async (_, cwd: string, command: string) => {
-    return startProcess(cwd, command);
-  });
+  ipcMain.handle(
+    "process:start",
+    async (_, cwd: string, command: string, restartConfig?: any) => {
+      return startProcess(cwd, command, restartConfig);
+    },
+  );
 
   // IPC handler for stopping a process
   ipcMain.handle("process:stop", async (_, processId: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -14,8 +14,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   validatePaths: (filePaths: string[]): Promise<[string[], string[]]> =>
     ipcRenderer.invoke("paths:validate", filePaths),
   // Process management
-  startProcess: (cwd: string, command: string) =>
-    ipcRenderer.invoke("process:start", cwd, command),
+  startProcess: (cwd: string, command: string, restartConfig?: any) =>
+    ipcRenderer.invoke("process:start", cwd, command, restartConfig),
   stopProcess: (processId: string) =>
     ipcRenderer.invoke("process:stop", processId),
   getProcessStatus: (processId: string) =>
@@ -29,6 +29,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
   removeProcessLogListener: () => {
     ipcRenderer.removeAllListeners("process-log");
+  },
+  // Process restart events
+  onProcessRestart: (callback: (data: any) => void) => {
+    ipcRenderer.on("process-restart", (_: any, data: any) => callback(data));
+  },
+  removeProcessRestartListener: () => {
+    ipcRenderer.removeAllListeners("process-restart");
+  },
+  onProcessCrash: (callback: (data: any) => void) => {
+    ipcRenderer.on("process-crash", (_: any, data: any) => callback(data));
+  },
+  removeProcessCrashListener: () => {
+    ipcRenderer.removeAllListeners("process-crash");
   },
   // Update management
   installUpdate: () => ipcRenderer.invoke("app:installUpdate"),

--- a/electron/utils/extractYamlConfig.test.ts
+++ b/electron/utils/extractYamlConfig.test.ts
@@ -123,6 +123,39 @@ const testCases: TestCase[] = [
     expectedErrors: [],
     shouldBeValid: true,
   },
+  {
+    name: "invalid restart config (missing enabled, invalid types)",
+    filename: "./electron/utils/test-files/invalid-restart-config.yml",
+    expectedErrors: [
+      {
+        message: "restart.enabled must be a boolean",
+        path: "processes[0].restart",
+      },
+      {
+        message: "restart.enabled must be a boolean",
+        path: "processes[1].restart",
+      },
+      {
+        message: "restart.max_retries must be a positive number",
+        path: "processes[2].restart",
+      },
+      {
+        message: "restart.delay_ms must be a non-negative number",
+        path: "processes[3].restart",
+      },
+      {
+        message: "restart.reset_after_ms must be a non-negative number",
+        path: "processes[4].restart",
+      },
+    ],
+    shouldBeValid: false,
+  },
+  {
+    name: "valid restart config",
+    filename: "./electron/utils/test-files/valid-restart-config.yml",
+    expectedErrors: [],
+    shouldBeValid: true,
+  },
 ];
 
 describe.concurrent("extractYamlConfig", async () => {

--- a/electron/utils/processManager.ts
+++ b/electron/utils/processManager.ts
@@ -1,12 +1,28 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { BrowserWindow } from "electron";
+import type { RestartConfig } from "@/electron/types";
 import { KillSignal, LogType } from "./enums";
 
 const PROCESS_KILL_TIMEOUT_MS = 10_000;
+// Update README.md if these values change
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_DELAY_MS = 1000;
+const DEFAULT_RESET_AFTER_MS = 30000;
+
+type ProcessState = {
+  childProcess: ChildProcess;
+  cwd: string;
+  command: string;
+  restartConfig?: RestartConfig;
+  retryCount: number;
+  lastStartTime: number;
+  manualStop: boolean;
+  restartTimer?: ReturnType<typeof setTimeout>;
+};
 
 // Process management state
-const runningProcesses = new Map<string, ChildProcess>();
+const runningProcesses = new Map<string, ProcessState>();
 
 export type ProcessStartResult = {
   success: boolean;
@@ -19,86 +35,190 @@ export type ProcessStopResult = {
   error?: string;
 };
 
+const sendToAllWindows = (channel: string, data: unknown) => {
+  BrowserWindow.getAllWindows().forEach((window) => {
+    window.webContents.send(channel, data);
+  });
+};
+
+const spawnProcess = (
+  processId: string,
+  cwd: string,
+  command: string,
+  restartConfig?: RestartConfig,
+  retryCount = 0,
+): ChildProcess => {
+  const childProcess = spawn(command, {
+    cwd: cwd || process.cwd(),
+    stdio: ["ignore", "pipe", "pipe"], // Need pipes to capture output
+    detached: true, // Create new process group
+    shell: true, // This allows the command to be executed as-is by the shell
+    env: {
+      ...process.env,
+      // Force colored output
+      FORCE_COLOR: "1",
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+    },
+  });
+
+  // Store process state
+  runningProcesses.set(processId, {
+    childProcess,
+    cwd,
+    command,
+    restartConfig,
+    retryCount,
+    lastStartTime: Date.now(),
+    manualStop: false,
+  });
+
+  // Stream stdout to renderer
+  childProcess.stdout?.on("data", (data) => {
+    sendToAllWindows("process-log", {
+      processId,
+      type: LogType.STDOUT,
+      output: data.toString(),
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  // Stream stderr to renderer
+  childProcess.stderr?.on("data", (data) => {
+    sendToAllWindows("process-log", {
+      processId,
+      type: LogType.STDERR,
+      output: data.toString(),
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  // Handle process exit
+  childProcess.on("exit", (code, signal) => {
+    handleProcessExit(processId, code, signal);
+  });
+
+  // Handle process error
+  childProcess.on("error", (error) => {
+    const state = runningProcesses.get(processId);
+    if (state) {
+      runningProcesses.delete(processId);
+    }
+    sendToAllWindows("process-log", {
+      processId,
+      type: LogType.ERROR,
+      output: error.message,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  return childProcess;
+};
+
+const handleProcessExit = (
+  processId: string,
+  code: number | null,
+  signal: string | null,
+) => {
+  const state = runningProcesses.get(processId);
+  if (!state) return;
+
+  const { restartConfig, manualStop, lastStartTime, retryCount, cwd, command } =
+    state;
+
+  // Clean up
+  runningProcesses.delete(processId);
+
+  // Send exit log
+  sendToAllWindows("process-log", {
+    processId,
+    type: LogType.EXIT,
+    code,
+    signal,
+    timestamp: new Date().toISOString(),
+  });
+
+  // Don't restart if:
+  // 1. Manual stop was requested
+  // 2. Clean exit (code === 0)
+  // 3. Restart is not enabled
+  if (manualStop || code === 0 || !restartConfig?.enabled) {
+    // Notify about crash if it was a non-zero exit (not manual stop and not clean exit)
+    if (!manualStop && code !== 0) {
+      sendToAllWindows("process-crash", {
+        processId,
+        exitCode: code,
+        signal,
+        willRestart: false,
+        timestamp: new Date().toISOString(),
+      });
+    }
+    return;
+  }
+
+  // Calculate effective config values
+  const maxRetries = restartConfig.max_retries ?? DEFAULT_MAX_RETRIES;
+  const delayMs = restartConfig.delay_ms ?? DEFAULT_DELAY_MS;
+  const resetAfterMs = restartConfig.reset_after_ms ?? DEFAULT_RESET_AFTER_MS;
+
+  // Check if we should reset the retry counter (process ran long enough)
+  const runDuration = Date.now() - lastStartTime;
+  const effectiveRetryCount = runDuration >= resetAfterMs ? 0 : retryCount;
+
+  // Check if we've exceeded max retries
+  if (effectiveRetryCount >= maxRetries) {
+    sendToAllWindows("process-crash", {
+      processId,
+      exitCode: code,
+      signal,
+      willRestart: false,
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+
+  // Notify about crash with restart pending
+  sendToAllWindows("process-crash", {
+    processId,
+    exitCode: code,
+    signal,
+    willRestart: true,
+    timestamp: new Date().toISOString(),
+  });
+
+  // Schedule restart
+  const restartTimer = setTimeout(() => {
+    const newRetryCount = effectiveRetryCount + 1;
+
+    // Notify about restart attempt
+    sendToAllWindows("process-restart", {
+      processId,
+      retryCount: newRetryCount,
+      maxRetries,
+      timestamp: new Date().toISOString(),
+    });
+
+    // Spawn new process with same ID
+    spawnProcess(processId, cwd, command, restartConfig, newRetryCount);
+  }, delayMs);
+
+  // Store the timer reference in case we need to cancel it
+  // We create a temporary entry just for the timer
+  runningProcesses.set(processId, {
+    ...state,
+    restartTimer,
+    manualStop: false,
+  } as ProcessState);
+};
+
 export const startProcess = async (
   cwd: string,
   command: string,
+  restartConfig?: RestartConfig,
 ): Promise<ProcessStartResult> => {
   try {
     const processId = randomUUID();
-
-    const childProcess = spawn(command, {
-      cwd: cwd || process.cwd(),
-      stdio: ["ignore", "pipe", "pipe"], // Need pipes to capture output
-      detached: true, // Create new process group
-      shell: true, // This allows the command to be executed as-is by the shell
-      env: {
-        ...process.env,
-        // Force colored output
-        FORCE_COLOR: "1",
-        TERM: "xterm-256color",
-        COLORTERM: "truecolor",
-      },
-    });
-
-    runningProcesses.set(processId, childProcess);
-
-    // Stream output to renderer process
-    childProcess.stdout?.on("data", (data) => {
-      const logData = {
-        processId,
-        type: LogType.STDOUT,
-        output: data.toString(),
-        timestamp: new Date().toISOString(),
-      };
-      // Send to all renderer processes
-      BrowserWindow.getAllWindows().forEach((window) => {
-        window.webContents.send("process-log", logData);
-      });
-    });
-
-    childProcess.stderr?.on("data", (data) => {
-      const logData = {
-        processId,
-        type: LogType.STDERR,
-        output: data.toString(),
-        timestamp: new Date().toISOString(),
-      };
-      // Send to all renderer processes
-      BrowserWindow.getAllWindows().forEach((window) => {
-        window.webContents.send("process-log", logData);
-      });
-    });
-
-    // Handle process exit
-    childProcess.on("exit", (code, signal) => {
-      runningProcesses.delete(processId);
-      // Notify renderer about process exit
-      const exitData = {
-        processId,
-        type: LogType.EXIT,
-        code,
-        signal,
-        timestamp: new Date().toISOString(),
-      };
-      BrowserWindow.getAllWindows().forEach((window) => {
-        window.webContents.send("process-log", exitData);
-      });
-    });
-
-    childProcess.on("error", (error) => {
-      runningProcesses.delete(processId);
-      // Notify renderer about process error
-      const errorData = {
-        processId,
-        type: LogType.ERROR,
-        output: error.message,
-        timestamp: new Date().toISOString(),
-      };
-      BrowserWindow.getAllWindows().forEach((window) => {
-        window.webContents.send("process-log", errorData);
-      });
-    });
-
+    spawnProcess(processId, cwd, command, restartConfig, 0);
     return { success: true, processId };
   } catch (error) {
     console.error("Error starting process:", error);
@@ -113,10 +233,21 @@ export const stopProcess = async (
   processId: string,
 ): Promise<ProcessStopResult> => {
   try {
-    const childProcess = runningProcesses.get(processId);
-    if (!childProcess) {
+    const state = runningProcesses.get(processId);
+    if (!state) {
       return { success: true };
     }
+
+    // Mark as manual stop to prevent auto-restart
+    state.manualStop = true;
+
+    // Cancel any pending restart timer
+    if (state.restartTimer) {
+      clearTimeout(state.restartTimer);
+      state.restartTimer = undefined;
+    }
+
+    const { childProcess } = state;
 
     // Kill the entire process group (negative PID)
     if (childProcess.pid) {
@@ -125,7 +256,8 @@ export const stopProcess = async (
 
     // Give process time to gracefully shut down, then force kill
     setTimeout(() => {
-      if (runningProcesses.has(processId) && childProcess.pid) {
+      const currentState = runningProcesses.get(processId);
+      if (currentState && childProcess.pid) {
         try {
           process.kill(-childProcess.pid, KillSignal.SIGKILL);
         } catch (_e) {
@@ -145,15 +277,16 @@ export const stopProcess = async (
 };
 
 export const stopAllProcesses = (): void => {
-  runningProcesses.forEach((_childProcess, processId) => {
+  runningProcesses.forEach((_state, processId) => {
     stopProcess(processId);
   });
 };
 
 export const isProcessRunning = async (processId: string): Promise<boolean> => {
   try {
-    const childProcess = runningProcesses.get(processId);
-    if (!childProcess) return false;
+    const state = runningProcesses.get(processId);
+    if (!state) return false;
+    const { childProcess } = state;
     return !childProcess.killed && childProcess.exitCode === null;
   } catch (_e) {
     console.error("Error checking process status:", _e);

--- a/electron/utils/test-files/invalid-restart-config.yml
+++ b/electron/utils/test-files/invalid-restart-config.yml
@@ -1,0 +1,30 @@
+project_name: "Invalid Restart Config"
+
+processes:
+  - name: "Missing enabled"
+    base_command: "echo test"
+    restart:
+      max_retries: 3
+
+  - name: "Invalid enabled type"
+    base_command: "echo test"
+    restart:
+      enabled: "yes"
+
+  - name: "Invalid max_retries"
+    base_command: "echo test"
+    restart:
+      enabled: true
+      max_retries: -1
+
+  - name: "Invalid delay_ms"
+    base_command: "echo test"
+    restart:
+      enabled: true
+      delay_ms: -100
+
+  - name: "Invalid reset_after_ms"
+    base_command: "echo test"
+    restart:
+      enabled: true
+      reset_after_ms: "30000"

--- a/electron/utils/test-files/valid-restart-config.yml
+++ b/electron/utils/test-files/valid-restart-config.yml
@@ -1,0 +1,18 @@
+project_name: "Valid Restart Config"
+
+processes:
+  - name: "Full Restart Config"
+    base_command: "echo test"
+    restart:
+      enabled: true
+      max_retries: 5
+      delay_ms: 2000
+      reset_after_ms: 60000
+
+  - name: "Minimal Restart Config"
+    base_command: "echo test"
+    restart:
+      enabled: false
+
+  - name: "No Restart Config"
+    base_command: "echo test"

--- a/example.yml
+++ b/example.yml
@@ -86,3 +86,14 @@ processes:
 
   - name: "Infinite Process"
     base_command: "bash ./resources/infinite-process.sh"
+
+  - name: "Crashing Process (Auto-Restart)"
+    base_command: "bash ./resources/crashing-process.sh 3 1"
+    restart:
+      enabled: true
+      max_retries: 3
+      delay_ms: 1000
+      reset_after_ms: 30000
+
+  - name: "Crashing Process (No Restart)"
+    base_command: "bash ./resources/crashing-process.sh 2 1"

--- a/resources/crashing-process.sh
+++ b/resources/crashing-process.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Simulates a process that crashes after a configurable delay
+# Used for testing auto-restart functionality
+
+# Default values
+crash_delay="${1:-3}"  # Default: crash after 3 seconds
+exit_code="${2:-1}"    # Default: exit with code 1
+
+echo "Crashing Process Started (PID: $$)"
+echo "Will crash in $crash_delay seconds with exit code $exit_code"
+echo "---"
+
+counter=0
+while [ $counter -lt $crash_delay ]; do
+  counter=$((counter + 1))
+  timestamp=$(date "+%H:%M:%S")
+  echo "[$timestamp] Running... ($counter/$crash_delay seconds)"
+  sleep 1
+done
+
+echo "---"
+echo "SIMULATING CRASH! Exiting with code $exit_code"
+exit $exit_code

--- a/src/features/dashboard/components/PlayStopButton.tsx
+++ b/src/features/dashboard/components/PlayStopButton.tsx
@@ -13,7 +13,12 @@ export const PlayStopButton = (props: PlayStopButtonProps) => {
 
   return (
     <Switch>
-      <Match when={status() === ProcessStatus.STOPPED}>
+      <Match
+        when={
+          status() === ProcessStatus.STOPPED ||
+          status() === ProcessStatus.CRASHED
+        }
+      >
         <button
           type="button"
           class="btn btn-primary btn-circle btn-sm"
@@ -38,6 +43,17 @@ export const PlayStopButton = (props: PlayStopButtonProps) => {
           type="button"
           class="btn btn-error btn-circle btn-sm"
           onClick={() => stopProcess(props.processName)}
+        >
+          <Square size={16} />
+        </button>
+      </Match>
+
+      <Match when={status() === ProcessStatus.RESTARTING}>
+        <button
+          type="button"
+          class="btn btn-warning btn-circle btn-sm"
+          onClick={() => stopProcess(props.processName)}
+          title="Cancel restart"
         >
           <Square size={16} />
         </button>

--- a/src/features/dashboard/contexts/DashboardContext.ts
+++ b/src/features/dashboard/contexts/DashboardContext.ts
@@ -13,6 +13,8 @@ export type ProcessData = {
   processId: ProcessId | null;
   startTime: Date | null;
   command: string;
+  retryCount: number;
+  maxRetries: number;
 };
 
 export type DashboardContextType = {

--- a/src/features/dashboard/enums.ts
+++ b/src/features/dashboard/enums.ts
@@ -3,4 +3,6 @@ export enum ProcessStatus {
   STARTING = "Starting",
   RUNNING = "Running",
   STOPPING = "Stopping",
+  CRASHED = "Crashed",
+  RESTARTING = "Restarting",
 }


### PR DESCRIPTION
- Add CRASHED and RESTARTING statuses to ProcessStatus enum
- Add RestartConfig type with enabled, max_retries, delay_ms, and reset_after_ms options
- Implement auto-restart logic in processManager.ts with retry counting
- Track process crash and restart events via IPC (process-crash, process-restart)
- Update DashboardProvider to handle crash/restart events and update UI state
- Show crash status with error badge and restart progress (retry/max) with warning badge
- Allow manual restart from crashed state and manual stop during restart
- Properly reset retry counter when process runs longer than reset_after_ms

Config example:
  restart:
    enabled: true
    max_retries: 3
    delay_ms: 1000
    reset_after_ms: 30000

https://claude.ai/code/session_01L4akFRKgief8E2cdj5nF2p