### PR TITLE
feat: add process grouping with collapsible groups and per-group controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - See [README.md](README.md) for more information.
 - 🚀 Added **crashed status** to distinguish between manually stopped and crashed processes.
 - 🚀 Added **working directory override**: new optional `cwd` field per process to run commands from a custom directory.
+- 🚀 Added **process grouping**: new optional `group` field per process to organize processes into collapsible groups.
 - ✨ Added **copy log line** button, visible on hover.
 - ✨ Added toast notifications when a process crashes.
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@
 - **Flexible configuration**: YAML-based setup with customizable arguments
 - **Process monitoring**: Real-time status, logs, and runtime tracking
 - **Argument types**: Toggle switches, dropdowns, and text inputs
+- **Environment variables**: Set custom env vars per process, merged with system environment
 - **Auto-restart**: Automatically restart crashed processes with configurable retry limits
+- **Process grouping**: Organize processes into collapsible groups with per-group start/stop
 
-| Homepage | Dashboard | Log Drawer |
-| --- | --- | --- |
+| Homepage                              | Dashboard                               | Log Drawer                                |
+| ------------------------------------- | --------------------------------------- | ----------------------------------------- |
 | ![Homepage](resources/1-homepage.png) | ![Dashboard](resources/2-dashboard.png) | ![Log Drawer](resources/3-log-drawer.png) |
 
 ## 📦 Installation
@@ -92,21 +94,22 @@ Create a `config.yml` file in your project directory to define your development 
 
 ### Root Configuration
 
-| YAML Path | Type | Required | Description | Example |
-|-----------|------|----------|-------------|---------|
-| `project_name` | `string` | ✅ | Display name for your project | `"My Dev Stack"` |
-| `processes` | `array` | ✅ | List of processes to manage (min: 1) | See process structure below |
+| YAML Path      | Type     | Required | Description                          | Example                     |
+| -------------- | -------- | -------- | ------------------------------------ | --------------------------- |
+| `project_name` | `string` | ✅       | Display name for your project        | `"My Dev Stack"`            |
+| `processes`    | `array`  | ✅       | List of processes to manage (min: 1) | See process structure below |
 
 ### Process Configuration
 
-| YAML Path | Type | Required | Description | Example |
-|-----------|------|----------|-------------|---------|
-| `processes[].name` | `string` | ✅ | Display name for the process | `"Web Server"` |
-| `processes[].base_command` | `string` | ✅ | Base command to execute | `"npm start"` |
-| `processes[].cwd` | `string` | ❌ | Working directory for the process (relative to config file or absolute) | `"./packages/api"` |
-| `processes[].env` | `object` | ❌ | Custom environment variables | See env config below |
-| `processes[].restart` | `object` | ❌ | Auto-restart configuration | See restart config below |
-| `processes[].args` | `array` | ❌ | List of configurable arguments | See argument types below |
+| YAML Path                  | Type     | Required | Description                                                             | Example                  |
+| -------------------------- | -------- | -------- | ----------------------------------------------------------------------- | ------------------------ |
+| `processes[].name`         | `string` | ✅       | Display name for the process                                            | `"Web Server"`           |
+| `processes[].base_command` | `string` | ✅       | Base command to execute                                                 | `"npm start"`            |
+| `processes[].group`        | `string` | ❌       | Group name for organizing processes                                     | `"Backend"`              |
+| `processes[].cwd`          | `string` | ❌       | Working directory for the process (relative to config file or absolute) | `"./packages/api"`       |
+| `processes[].env`          | `object` | ❌       | Custom environment variables                                            | See env config below     |
+| `processes[].restart`      | `object` | ❌       | Auto-restart configuration                                              | See restart config below |
+| `processes[].args`         | `array`  | ❌       | List of configurable arguments                                          | See argument types below |
 
 ### Environment Variables Configuration
 
@@ -129,16 +132,27 @@ processes:
 - Empty string values are allowed (useful for declaring a variable exists)
 - Values override any existing system environment variables with the same name
 
+### Process Grouping Configuration
+
+Add an optional `group` field to organize processes into collapsible groups. Processes sharing the same group are displayed together with Start All / Stop All controls. Ungrouped processes appear in an "Other" section.
+
+```yaml
+processes:
+  - name: "PostgreSQL"
+    group: "Infrastructure"
+    base_command: "docker compose up postgres"
+```
+
 ### Restart Configuration
 
 Configure automatic restart behavior for processes that crash unexpectedly.
 
-| YAML Path | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `restart.enabled` | `boolean` | ✅ | - | Enable/disable auto-restart |
-| `restart.max_retries` | `number` | ❌ | `3` | Max consecutive restart attempts before giving up |
-| `restart.delay_ms` | `number` | ❌ | `1000` | Delay in milliseconds before restarting |
-| `restart.reset_after_ms` | `number` | ❌ | `30000` | Reset retry counter if process runs longer than this |
+| YAML Path                | Type      | Required | Default | Description                                          |
+| ------------------------ | --------- | -------- | ------- | ---------------------------------------------------- |
+| `restart.enabled`        | `boolean` | ✅       | -       | Enable/disable auto-restart                          |
+| `restart.max_retries`    | `number`  | ❌       | `3`     | Max consecutive restart attempts before giving up    |
+| `restart.delay_ms`       | `number`  | ❌       | `1000`  | Delay in milliseconds before restarting              |
+| `restart.reset_after_ms` | `number`  | ❌       | `30000` | Reset retry counter if process runs longer than this |
 
 **Behavior:**
 
@@ -149,33 +163,33 @@ Configure automatic restart behavior for processes that crash unexpectedly.
 
 ### Argument Configuration (All Types)
 
-| YAML Path | Type | Required | Description | Example |
-|-----------|------|----------|-------------|---------|
-| `args[].type` | `string` | ✅ | Argument type: `toggle`, `select`, or `input` | `"toggle"` |
-| `args[].name` | `string` | ✅ | Display name in UI | `"Watch Mode"` |
-| `args[].default` | `any` | ✅ | Default value (type depends on arg type) | `true`, `"development"`, `"3000"` |
+| YAML Path        | Type     | Required | Description                                   | Example                           |
+| ---------------- | -------- | -------- | --------------------------------------------- | --------------------------------- |
+| `args[].type`    | `string` | ✅       | Argument type: `toggle`, `select`, or `input` | `"toggle"`                        |
+| `args[].name`    | `string` | ✅       | Display name in UI                            | `"Watch Mode"`                    |
+| `args[].default` | `any`    | ✅       | Default value (type depends on arg type)      | `true`, `"development"`, `"3000"` |
 
 ### Toggle-Specific Configuration
 
-| YAML Path | Type | Required | Description | Example |
-|-----------|------|----------|-------------|---------|
-| `args[].values` | `array` | ✅ | Exactly 2 values: one for `true`, one for `false` | See toggle example |
-| `args[].values[].value` | `boolean` | ✅ | Must be `true` or `false` | `true` |
-| `args[].values[].output` | `string` | ❌ | Command line output (can be empty) | `"--watch"` |
+| YAML Path                | Type      | Required | Description                                       | Example            |
+| ------------------------ | --------- | -------- | ------------------------------------------------- | ------------------ |
+| `args[].values`          | `array`   | ✅       | Exactly 2 values: one for `true`, one for `false` | See toggle example |
+| `args[].values[].value`  | `boolean` | ✅       | Must be `true` or `false`                         | `true`             |
+| `args[].values[].output` | `string`  | ❌       | Command line output (can be empty)                | `"--watch"`        |
 
 ### Select-Specific Configuration
 
-| YAML Path | Type | Required | Description | Example |
-|-----------|------|----------|-------------|---------|
-| `args[].values` | `array` | ✅ | List of options (min: 2) | See select example |
-| `args[].values[].value` | `string` | ✅ | Option value | `"development"` |
-| `args[].values[].output` | `string` | ❌ | Command line output (can be empty) | `"--env=development"` |
+| YAML Path                | Type     | Required | Description                        | Example               |
+| ------------------------ | -------- | -------- | ---------------------------------- | --------------------- |
+| `args[].values`          | `array`  | ✅       | List of options (min: 2)           | See select example    |
+| `args[].values[].value`  | `string` | ✅       | Option value                       | `"development"`       |
+| `args[].values[].output` | `string` | ❌       | Command line output (can be empty) | `"--env=development"` |
 
 ### Input-Specific Configuration
 
-| YAML Path | Type | Required | Description | Example |
-|-----------|------|----------|-------------|---------|
-| `args[].output_prefix` | `string` | ❌ | Prefix added to user input | `"--port"` |
+| YAML Path              | Type     | Required | Description                | Example    |
+| ---------------------- | -------- | -------- | -------------------------- | ---------- |
+| `args[].output_prefix` | `string` | ❌       | Prefix added to user input | `"--port"` |
 
 ### Example Configuration
 
@@ -184,6 +198,7 @@ project_name: "Development Services"
 
 processes:
   - name: "Web Server"
+    group: "Frontend"
     base_command: "pnpm start"
     restart:
       enabled: true

--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,8 @@ This document outlines planned improvements for Click-Launch. Each section conta
 
 1. [Environment Variables UI](#1-environment-variables-ui)
 2. [Log Export/Save](#2-log-exportsave)
-3. [Process Grouping/Tags](#3-process-groupingtags)
-4. [Settings/Preferences Panel](#4-settingspreferences-panel)
-5. [Resource Monitoring](#5-resource-monitoring)
+3. [Settings/Preferences Panel](#3-settingspreferences-panel)
+4. [Resource Monitoring](#4-resource-monitoring)
 
 ---
 
@@ -144,105 +143,7 @@ export const stripAnsiCodes = (text: string): string => { ... }
 
 ---
 
-## 3. Process Grouping/Tags
-
-**Priority:** Medium
-**Complexity:** Medium
-**Feature:** Organize processes into collapsible groups for better organization
-
-### User Story
-
-As a developer with many processes, I want to organize them into groups (e.g., "Backend", "Frontend", "Infrastructure") so that I can manage related processes together.
-
-### Configuration Schema
-
-```yaml
-processes:
-  - name: "PostgreSQL"
-    group: "Infrastructure"
-    base_command: "docker compose up postgres"
-
-  - name: "Redis"
-    group: "Infrastructure"
-    base_command: "docker compose up redis"
-
-  - name: "API Server"
-    group: "Backend"
-    base_command: "pnpm start:api"
-
-  - name: "Web App"
-    group: "Frontend"
-    base_command: "pnpm start:web"
-
-  - name: "Standalone Process"  # No group - shows in "Other" or ungrouped
-    base_command: "pnpm start:worker"
-```
-
-### Implementation Details
-
-#### Files to Modify
-
-1. **`electron/utils/extractYamlConfig.ts`**
-   - Add optional `group: string` field to `ProcessConfig`
-   - Validate group name (non-empty string if provided)
-
-2. **`src/features/dashboard/contexts/DashboardContext.ts`**
-   - Add helper to group processes: `getProcessesByGroup()`
-   - Track collapsed state per group
-
-3. **`src/features/dashboard/components/ProcessTable.tsx`**
-   - Render processes grouped by their `group` field
-   - Add collapsible group headers with expand/collapse toggle
-   - Show process count per group
-   - Add "Start Group" / "Stop Group" buttons on group headers
-
-4. **`src/features/dashboard/components/ProcessGroupHeader.tsx`** (new)
-   - Group header component with:
-     - Group name
-     - Process count (running/total)
-     - Expand/collapse chevron
-     - Start all / Stop all buttons for group
-
-#### UI Behavior
-
-- Groups are collapsible (click header to toggle)
-- Collapsed state persists in localStorage
-- Ungrouped processes appear in "Other" section or at the top
-- Group order: alphabetical, with "Other" last
-- Visual distinction between groups (subtle separator or background)
-
-#### Group Header Design
-
-```
-▼ Infrastructure (2/3 running)              [▶ Start All] [■ Stop All]
-  ├─ PostgreSQL                             [Running] [■]
-  ├─ Redis                                  [Running] [■]
-  └─ Elasticsearch                          [Stopped] [▶]
-
-▶ Backend (0/2 running)                     [▶ Start All] [■ Stop All]
-  (collapsed)
-```
-
-#### Data Structure
-
-```typescript
-type GroupedProcesses = {
-  [groupName: string]: ProcessConfig[];
-};
-
-const groupProcesses = (processes: ProcessConfig[]): GroupedProcesses => {
-  return processes.reduce((acc, process) => {
-    const group = process.group || 'Other';
-    acc[group] = acc[group] || [];
-    acc[group].push(process);
-    return acc;
-  }, {} as GroupedProcesses);
-};
-```
-
----
-
-## 4. Settings/Preferences Panel
+## 3. Settings/Preferences Panel
 
 **Priority:** Medium
 **Complexity:** Medium
@@ -348,7 +249,7 @@ type Settings = {
 
 ---
 
-## 5. Resource Monitoring
+## 4. Resource Monitoring
 
 **Priority:** Medium
 **Complexity:** High
@@ -458,8 +359,7 @@ Suggested implementation order based on value and dependencies:
 1. **Environment Variables UI** - Medium effort, completes env vars feature
 2. **Log Export** - Low effort, frequently requested
 3. **Settings Panel** - Medium effort, enables other features
-4. **Process Grouping** - Medium effort, helps larger projects
-5. **Resource Monitoring** - High effort, nice to have
+4. **Resource Monitoring** - High effort, nice to have
 
 ---
 

--- a/electron/utils/extractYamlConfig.test.ts
+++ b/electron/utils/extractYamlConfig.test.ts
@@ -206,6 +206,27 @@ const testCases: TestCase[] = [
     ],
     shouldBeValid: false,
   },
+  {
+    name: "valid group config (with groups and without)",
+    filename: "./electron/utils/test-files/valid-group-config.yml",
+    expectedErrors: [],
+    shouldBeValid: true,
+  },
+  {
+    name: "invalid group config (non-string and empty)",
+    filename: "./electron/utils/test-files/invalid-group-config.yml",
+    expectedErrors: [
+      {
+        message: "group must be a non-empty string",
+        path: "processes[0]",
+      },
+      {
+        message: "group must be a non-empty string",
+        path: "processes[1]",
+      },
+    ],
+    shouldBeValid: false,
+  },
 ];
 
 describe.concurrent("extractYamlConfig", async () => {

--- a/electron/utils/extractYamlConfig.ts
+++ b/electron/utils/extractYamlConfig.ts
@@ -25,6 +25,7 @@ export type YamlConfig = {
   processes: {
     name: string;
     base_command: string;
+    group?: string;
     cwd?: string;
     env?: ProcessEnv;
     restart?: RestartConfig;
@@ -118,6 +119,14 @@ const validateProcess = (
     path: basePath,
     errors,
   });
+  if (process.group !== undefined) {
+    validateString({
+      fieldName: "group",
+      value: process.group,
+      path: basePath,
+      errors,
+    });
+  }
   if (process.cwd !== undefined) {
     validateString({
       fieldName: "cwd",

--- a/electron/utils/test-files/invalid-group-config.yml
+++ b/electron/utils/test-files/invalid-group-config.yml
@@ -1,0 +1,10 @@
+project_name: "Invalid Group Test"
+
+processes:
+  - name: "Process with numeric group"
+    base_command: "echo test"
+    group: 123
+
+  - name: "Process with empty group"
+    base_command: "echo test"
+    group: ""

--- a/electron/utils/test-files/valid-group-config.yml
+++ b/electron/utils/test-files/valid-group-config.yml
@@ -1,0 +1,13 @@
+project_name: "Group Test Project"
+
+processes:
+  - name: "Process with group"
+    base_command: "echo hello"
+    group: "Infrastructure"
+
+  - name: "Process with another group"
+    base_command: "echo world"
+    group: "Backend"
+
+  - name: "Process without group"
+    base_command: "echo default"

--- a/example.yml
+++ b/example.yml
@@ -2,6 +2,7 @@ project_name: "Development Services"
 
 processes:
   - name: "Web Server"
+    group: "Frontend"
     base_command: "bash ./resources/web-server.sh"
     env:
       NODE_ENV: development
@@ -34,6 +35,7 @@ processes:
         output_prefix: "--port"
 
   - name: "Database"
+    group: "Infrastructure"
     base_command: "bash ./resources/database.sh"
     args:
       - type: "select"
@@ -64,6 +66,7 @@ processes:
         output_prefix: "--port"
 
   - name: "API Server"
+    group: "Backend"
     base_command: "bash ./resources/api-server.sh"
     args:
       - type: "toggle"
@@ -89,9 +92,11 @@ processes:
     base_command: "bash ./resources/counter-with-replacement.sh"
 
   - name: "Infinite Process"
+    group: "Infrastructure"
     base_command: "bash ./resources/infinite-process.sh"
 
   - name: "Crashing Process (Auto-Restart)"
+    group: "Backend"
     base_command: "bash ./resources/crashing-process.sh 3 1"
     restart:
       enabled: true
@@ -103,5 +108,6 @@ processes:
     base_command: "bash ./resources/crashing-process.sh 2 1"
 
   - name: "Show Working Directory"
+    group: "Infrastructure"
     base_command: "bash show-cwd.sh"
     cwd: "./resources"

--- a/src/electron/types.ts
+++ b/src/electron/types.ts
@@ -26,6 +26,7 @@ export type YamlConfig = {
   processes: {
     name: string;
     base_command: string;
+    group?: string;
     cwd?: string;
     env?: ProcessEnv;
     restart?: RestartConfig;

--- a/src/features/dashboard/components/ProcessGroupHeader.tsx
+++ b/src/features/dashboard/components/ProcessGroupHeader.tsx
@@ -1,0 +1,70 @@
+import { ChevronDown, ChevronRight, Play, Square } from "lucide-solid";
+import { createMemo, Show } from "solid-js";
+import { useDashboardContext } from "../contexts/";
+
+type ProcessGroupHeaderProps = {
+  groupName: string;
+  totalCount: number;
+};
+
+export const ProcessGroupHeader = (props: ProcessGroupHeaderProps) => {
+  const {
+    isGroupCollapsed,
+    toggleGroupCollapsed,
+    getGroupRunningCount,
+    startGroup,
+    stopGroup,
+  } = useDashboardContext();
+
+  const collapsed = () => isGroupCollapsed(props.groupName);
+  const runningCount = () => getGroupRunningCount(props.groupName);
+
+  const hasRunning = createMemo(() => runningCount() > 0);
+  const hasStopped = createMemo(() => runningCount() < props.totalCount);
+
+  return (
+    <tr class="bg-base-300">
+      <td colspan="3" class="p-2!">
+        <div class="flex items-center justify-between">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm gap-2 px-1"
+            onClick={() => toggleGroupCollapsed(props.groupName)}
+          >
+            <Show when={collapsed()} fallback={<ChevronDown size={16} />}>
+              <ChevronRight size={16} />
+            </Show>
+            <span>{props.groupName}</span>
+            <span class="badge badge-sm badge-neutral">
+              {runningCount()}/{props.totalCount} running
+            </span>
+          </button>
+          <div class="flex items-center gap-1">
+            <Show when={hasStopped()}>
+              <button
+                type="button"
+                class="btn btn-primary btn-xs"
+                onClick={() => startGroup(props.groupName)}
+                title="Start all in group"
+              >
+                <Play size={12} />
+                Start All
+              </button>
+            </Show>
+            <Show when={hasRunning()}>
+              <button
+                type="button"
+                class="btn btn-error btn-xs"
+                onClick={() => stopGroup(props.groupName)}
+                title="Stop all in group"
+              >
+                <Square size={12} />
+                Stop All
+              </button>
+            </Show>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+};

--- a/src/features/dashboard/components/ProcessTable.tsx
+++ b/src/features/dashboard/components/ProcessTable.tsx
@@ -1,17 +1,17 @@
-import { createSignal, For } from "solid-js";
+import { createSignal, For, Show } from "solid-js";
 import { useDashboardContext } from "../contexts";
+import { ProcessGroupHeader } from "./ProcessGroupHeader";
 import { ProcessLogDrawer } from "./ProcessLogDrawer";
 import { ProcessRow } from "./ProcessRow";
 
 export const ProcessTable = () => {
-  const { yamlConfig, rootDirectory } = useDashboardContext();
+  const { rootDirectory, getGroupedProcesses, hasGroups, isGroupCollapsed } =
+    useDashboardContext();
   const [selectedProcessName, setSelectedProcessName] = createSignal<
     string | null
   >(null);
 
   let drawerCheckboxRef!: HTMLInputElement;
-
-  const processes = () => yamlConfig()?.processes || [];
 
   const openModal = (processName: string) => {
     setSelectedProcessName(processName);
@@ -42,14 +42,28 @@ export const ProcessTable = () => {
               </tr>
             </thead>
             <tbody>
-              <For each={processes()}>
-                {(process, index) => (
-                  <ProcessRow
-                    process={process}
-                    index={index()}
-                    rootDirectory={rootDirectory()!}
-                    onOpenModal={openModal}
-                  />
+              <For each={getGroupedProcesses()}>
+                {(group) => (
+                  <>
+                    <Show when={hasGroups()}>
+                      <ProcessGroupHeader
+                        groupName={group.name}
+                        totalCount={group.processes.length}
+                      />
+                    </Show>
+                    <Show when={!hasGroups() || !isGroupCollapsed(group.name)}>
+                      <For each={group.processes}>
+                        {(process, index) => (
+                          <ProcessRow
+                            process={process}
+                            index={index()}
+                            rootDirectory={rootDirectory()!}
+                            onOpenModal={openModal}
+                          />
+                        )}
+                      </For>
+                    </Show>
+                  </>
                 )}
               </For>
             </tbody>

--- a/src/features/dashboard/contexts/DashboardContext.ts
+++ b/src/features/dashboard/contexts/DashboardContext.ts
@@ -1,6 +1,7 @@
 import { createContext } from "solid-js";
 import type {
   ArgConfig,
+  ProcessConfig,
   ProcessId,
   ValidationResult,
   YamlConfig,
@@ -17,6 +18,11 @@ export type ProcessData = {
   maxRetries: number;
 };
 
+export type GroupedProcesses = {
+  name: string;
+  processes: ProcessConfig[];
+};
+
 export type DashboardContextType = {
   isLoading: () => boolean;
   yamlConfig: () => YamlConfig | null;
@@ -24,6 +30,14 @@ export type DashboardContextType = {
   errors: () => ValidationResult["errors"];
   parseFile: () => Promise<void>;
   hasRunningProcesses: () => boolean;
+  // Group-related
+  getGroupedProcesses: () => GroupedProcesses[];
+  hasGroups: () => boolean;
+  isGroupCollapsed: (groupName: string) => boolean;
+  toggleGroupCollapsed: (groupName: string) => void;
+  getGroupRunningCount: (groupName: string) => number;
+  startGroup: (groupName: string) => Promise<void>;
+  stopGroup: (groupName: string) => Promise<void>;
   // Process-specific data and actions
   getProcessData: (processName: string) => ProcessData | undefined;
   getProcessCommand: (processName: string) => string;


### PR DESCRIPTION
Add optional `group` field to process configuration that organizes
processes into collapsible groups in the dashboard. Each group header
shows running/total count and Start All / Stop All buttons. Groups
are sorted alphabetically with ungrouped processes in "Other" last.