### PR TITLE
feat: add copy button on log lines with hover reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - See [README.md](README.md) for more information.
 - 🚀 Added **crashed status** to distinguish between manually stopped and crashed processes.
 - 🚀 Added **working directory override**: new optional `cwd` field per process to run commands from a custom directory.
+- ✨ Added **copy log line** button: hover over any log line to reveal a copy icon on the left.
 - ✨ Added toast notifications when a process crashes.
 
 ## 1.5.0 - 2026-01-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   - See [README.md](README.md) for more information.
 - 🚀 Added **crashed status** to distinguish between manually stopped and crashed processes.
 - 🚀 Added **working directory override**: new optional `cwd` field per process to run commands from a custom directory.
-- ✨ Added **copy log line** button: hover over any log line to reveal a copy icon on the left.
+- ✨ Added **copy log line** button, visible on hover.
 - ✨ Added toast notifications when a process crashes.
 
 ## 1.5.0 - 2026-01-24

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@
 - **Visual interface**: GUI for starting, stopping, and monitoring processes
 - **Flexible configuration**: YAML-based setup with customizable arguments
 - **Process monitoring**: Real-time status, logs, and runtime tracking
-- **Copy log lines**: Hover over any log line to quickly copy it to clipboard
 - **Argument types**: Toggle switches, dropdowns, and text inputs
 - **Auto-restart**: Automatically restart crashed processes with configurable retry limits
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - **Visual interface**: GUI for starting, stopping, and monitoring processes
 - **Flexible configuration**: YAML-based setup with customizable arguments
 - **Process monitoring**: Real-time status, logs, and runtime tracking
+- **Copy log lines**: Hover over any log line to quickly copy it to clipboard
 - **Argument types**: Toggle switches, dropdowns, and text inputs
 - **Auto-restart**: Automatically restart crashed processes with configurable retry limits
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,6 @@ This document outlines planned improvements for Click-Launch. Each section conta
 4. [Process Grouping/Tags](#4-process-groupingtags)
 5. [Settings/Preferences Panel](#5-settingspreferences-panel)
 6. [Resource Monitoring](#6-resource-monitoring)
-7. [Copy Log Line](#7-copy-log-line)
 
 ---
 
@@ -547,112 +546,6 @@ const getProcessStats = (pid: number): Promise<{ cpu: number; memory: number }> 
 
 ---
 
-## 7. Copy Log Line
-
-**Priority:** Low
-**Complexity:** Low
-**Feature:** Allow copying individual log lines or the full command
-
-### User Story
-
-As a developer, I want to quickly copy log lines or the process command so that I can share them or use them in other contexts.
-
-### UI Design
-
-#### Option A: Right-click context menu
-
-Right-click on a log line shows:
-
-- "Copy line"
-- "Copy line (without timestamp)"
-- "Copy all visible logs"
-
-#### Option B: Hover action button
-
-On hover, show a small copy icon on the right side of each log line.
-
-#### Command Copy
-
-Add copy button next to the command display in the log drawer header.
-
-### Implementation Details
-
-#### Files to Modify
-
-1. **`src/features/dashboard/components/ProcessLogDrawer.tsx`**
-   - Add copy button next to command display
-   - Implement copy to clipboard functionality
-
-2. **`src/features/dashboard/components/LogLine.tsx`** (may need to create)
-   - Extract log line into separate component
-   - Add hover state with copy button
-   - Or add right-click context menu
-
-3. **`src/utils/clipboard.ts`** (new)
-   - Utility for clipboard operations
-   - Handle copy with fallback for older browsers
-
-#### Clipboard Implementation
-
-```typescript
-export const copyToClipboard = async (text: string): Promise<boolean> => {
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    // Fallback for older browsers
-    const textArea = document.createElement('textarea');
-    textArea.value = text;
-    document.body.appendChild(textArea);
-    textArea.select();
-    const success = document.execCommand('copy');
-    document.body.removeChild(textArea);
-    return success;
-  }
-};
-```
-
-#### Log Line Component
-
-```tsx
-const LogLine = (props: { log: ProcessLog; onCopy: () => void }) => {
-  const [showCopy, setShowCopy] = createSignal(false);
-
-  return (
-    <div
-      class="log-line"
-      onMouseEnter={() => setShowCopy(true)}
-      onMouseLeave={() => setShowCopy(false)}
-    >
-      <span class="timestamp">{formatTimestamp(props.log.timestamp)}</span>
-      <span class="message" innerHTML={parseAnsi(props.log.message)} />
-      <Show when={showCopy()}>
-        <button
-          class="copy-btn"
-          onClick={() => {
-            copyToClipboard(props.log.message);
-            toast.success('Copied to clipboard');
-          }}
-        >
-          <Copy size={14} />
-        </button>
-      </Show>
-    </div>
-  );
-};
-```
-
-#### Toast Feedback
-
-Show brief toast notification on successful copy:
-
-- "Copied to clipboard"
-- "Command copied"
-
-Use existing `solid-toast` integration.
-
----
-
 ## Implementation Priority
 
 Suggested implementation order based on value and dependencies:
@@ -660,10 +553,9 @@ Suggested implementation order based on value and dependencies:
 1. **Environment Variables UI** - Medium effort, completes env vars feature
 2. **Log Export** - Low effort, frequently requested
 3. **Keyboard Shortcuts Reference** - Low effort, improves discoverability
-4. **Copy Log Line** - Low effort, quality of life
-5. **Settings Panel** - Medium effort, enables other features
-6. **Process Grouping** - Medium effort, helps larger projects
-7. **Resource Monitoring** - High effort, nice to have
+4. **Settings Panel** - Medium effort, enables other features
+5. **Process Grouping** - Medium effort, helps larger projects
+6. **Resource Monitoring** - High effort, nice to have
 
 ---
 

--- a/src/features/dashboard/components/ProcessLogDrawer.tsx
+++ b/src/features/dashboard/components/ProcessLogDrawer.tsx
@@ -599,7 +599,7 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
                 </div>
               }
             >
-              <div class={`font-mono text-sm space-y-1`}>
+              <div class={`font-mono text-sm space-y-1 pl-1`}>
                 <For each={displayedLogs()}>
                   {(log) => {
                     const isCurrentMatch = () => selectedLogId() === log.id;

--- a/src/features/dashboard/components/ProcessLogRow.tsx
+++ b/src/features/dashboard/components/ProcessLogRow.tsx
@@ -83,7 +83,7 @@ export const ProcessLogRow = (props: ProcessLogRowProps) => {
     >
       <button
         type="button"
-        class="absolute -left-5 top-0.5 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer text-gray-400 hover:text-white p-0.5"
+        class="btn btn-ghost btn-xs absolute -left-5 top-0 opacity-0 group-hover:opacity-100 transition-opacity min-h-0 h-auto p-0.5"
         onClick={() => copyLogLine(logOutput())}
         title="Copy log line"
       >

--- a/src/features/dashboard/components/ProcessLogRow.tsx
+++ b/src/features/dashboard/components/ProcessLogRow.tsx
@@ -1,4 +1,6 @@
+import { Copy } from "lucide-solid";
 import { createMemo, For, type JSX } from "solid-js";
+import toast from "solid-toast";
 import { LogType } from "@/electron/enums";
 import type { ProcessLogData } from "@/electron/types";
 import { parseAnsiToSegments } from "@/utils/ansiToHtml";
@@ -33,6 +35,13 @@ const highlightSearchTerm = (
   );
 };
 
+const copyLogLine = (text: string) => {
+  navigator.clipboard.writeText(text).then(
+    () => toast.success("Copied to clipboard"),
+    () => toast.error("Failed to copy"),
+  );
+};
+
 export const ProcessLogRow = (props: ProcessLogRowProps) => {
   if (props.log.type === LogType.EXIT) {
     return (
@@ -44,10 +53,12 @@ export const ProcessLogRow = (props: ProcessLogRowProps) => {
     );
   }
 
+  const logOutput = () =>
+    props.log.type === LogType.EXIT ? "" : props.log.output;
+
   // Memoize expensive ANSI parsing - only recompute when log output changes
   const segments = createMemo(() => {
-    const output = props.log.type === LogType.EXIT ? "" : props.log.output;
-    return parseAnsiToSegments(output || "");
+    return parseAnsiToSegments(logOutput() || "");
   });
 
   // Memoize search regex - only recreate when search term changes
@@ -66,10 +77,18 @@ export const ProcessLogRow = (props: ProcessLogRowProps) => {
   return (
     <div
       ref={props.ref}
-      class={`${
+      class={`group relative ${
         props.isCurrentMatch ? "bg-gray-700 rounded" : ""
       } whitespace-pre-wrap wrap-break-word`}
     >
+      <button
+        type="button"
+        class="absolute -left-5 top-0.5 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer text-gray-400 hover:text-white p-0.5"
+        onClick={() => copyLogLine(logOutput())}
+        title="Copy log line"
+      >
+        <Copy size={14} />
+      </button>
       <span class="text-gray-400 italic">[{props.log.timestamp}] </span>
       <For each={segments()}>
         {(segment) => (


### PR DESCRIPTION
Add a copy icon button on each log line in the log drawer that appears
on hover, positioned absolutely on the left side without impacting layout.
Uses navigator.clipboard API with toast feedback via solid-toast.
