### PR TITLE
feat: add keyboard shortcuts reference modal in log drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## TBD
 
-- 🚀 Added **keyboard shortcuts reference**: press `Cmd/Ctrl + /` in the log drawer to view all available shortcuts in a modal overlay using `kbd` styled keys.
+- 🚀 Added **keyboard shortcuts reference** in the log drawer. Press `⌘ + /` to view them.
 - 🚀 Added **environment variables support**: new optional `env` field per process to define custom environment variables.
 - 🚀 Added **process auto-restart** feature:
   - New `restart` YAML configuration option to configure auto-restart behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## TBD
 
+- 🚀 Added **keyboard shortcuts reference**: press `Cmd/Ctrl + /` in the log drawer to view all available shortcuts in a modal overlay using `kbd` styled keys.
 - 🚀 Added **environment variables support**: new optional `env` field per process to define custom environment variables.
 - 🚀 Added **process auto-restart** feature:
   - New `restart` YAML configuration option to configure auto-restart behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,24 @@ Use `index.ts` at every level **except** `src/components/`:
 - Named exports only (no default exports, except for page components)
 - No SSR/server components—this is a static frontend
 
+### Styling (DaisyUI + Tailwind)
+
+**DaisyUI First:**
+
+- ✅ Use DaisyUI components for UI elements: `btn`, `modal`, `card`, `menu`, `kbd`, `badge`, etc.
+- ✅ Use DaisyUI semantic colors: `bg-base-100`, `text-base-content`, `btn-primary`, etc.
+- ✅ Use DaisyUI modifiers: `btn-sm`, `btn-ghost`, `modal-open`, `rounded-box`, etc.
+- ✅ Refer to the DaisyUI documentation for available modifiers and components.
+- ❌ Avoid raw Tailwind for things DaisyUI handles (buttons, modals, cards, menus, etc.)
+
+**Tailwind for Fine-Tuning:**
+
+- ✅ Use Tailwind for layout: `flex`, `grid`, `gap-*`, `space-y-*`
+- ✅ Use Tailwind for positioning: `absolute`, `relative`, `inset-0`
+- ✅ Use Tailwind for spacing adjustments: `mt-4`, `px-2`, `py-1.5`
+- ✅ Use Tailwind for transitions: `transition-opacity`, `duration-200`
+- ✅ Use Tailwind for custom sizing when DaisyUI sizes don't fit
+
 ### SolidJS Patterns
 
 **Control Flow (Critical):**

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
     - [Input-Specific Configuration](#input-specific-configuration)
     - [Example Configuration](#example-configuration)
   - [🚀 Usage](#-usage)
+  - [⌨️ Keyboard Shortcuts](#️-keyboard-shortcuts)
   - [🤝 Contributing](#-contributing)
   - [📄 License](#-license)
   - [💬 Support](#-support)
@@ -234,6 +235,19 @@ processes:
 4. **Launch processes**: Click the play button next to each service
 5. **Monitor**: View real-time logs and runtime information
 6. **Stop when done**: Use stop buttons or close the app
+
+## ⌨️ Keyboard Shortcuts
+
+Press `Cmd/Ctrl + /` while the log drawer is open to display the full keyboard shortcuts reference. You can also click the shortcut hint at the bottom-right of the log drawer.
+
+| Shortcut | Context | Description |
+|----------|---------|-------------|
+| `Cmd/Ctrl + /` | Log Drawer | Show keyboard shortcuts |
+| `Cmd/Ctrl + F` | Log Drawer | Focus search input |
+| `Escape` | Log Drawer | Close shortcuts modal or drawer |
+| `Enter` | Log Drawer (search) | Next search result |
+| `Shift + Enter` | Log Drawer (search) | Previous search result |
+| `F5` / `Cmd/Ctrl + R` | Dashboard | Reload configuration |
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -238,16 +238,15 @@ processes:
 
 ## ⌨️ Keyboard Shortcuts
 
-Press `Cmd/Ctrl + /` while the log drawer is open to display the full keyboard shortcuts reference. You can also click the shortcut hint at the bottom-right of the log drawer.
+Press `⌘ + /` while the log drawer is open to display the keyboard shortcuts reference.
 
-| Shortcut | Context | Description |
-|----------|---------|-------------|
-| `Cmd/Ctrl + /` | Log Drawer | Show keyboard shortcuts |
-| `Cmd/Ctrl + F` | Log Drawer | Focus search input |
-| `Escape` | Log Drawer | Close shortcuts modal or drawer |
-| `Enter` | Log Drawer (search) | Next search result |
-| `Shift + Enter` | Log Drawer (search) | Previous search result |
-| `F5` / `Cmd/Ctrl + R` | Dashboard | Reload configuration |
+| Shortcut | Description |
+|----------|-------------|
+| `⌘ + /` | Show keyboard shortcuts |
+| `⌘ + F` | Focus search input |
+| `Escape` | Close shortcuts modal or drawer |
+| `Enter` | Next search result |
+| `Shift + Enter` | Previous search result |
 
 ## 🤝 Contributing
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,10 +8,9 @@ This document outlines planned improvements for Click-Launch. Each section conta
 
 1. [Environment Variables UI](#1-environment-variables-ui)
 2. [Log Export/Save](#2-log-exportsave)
-3. [Keyboard Shortcuts Reference](#3-keyboard-shortcuts-reference)
-4. [Process Grouping/Tags](#4-process-groupingtags)
-5. [Settings/Preferences Panel](#5-settingspreferences-panel)
-6. [Resource Monitoring](#6-resource-monitoring)
+3. [Process Grouping/Tags](#3-process-groupingtags)
+4. [Settings/Preferences Panel](#4-settingspreferences-panel)
+5. [Resource Monitoring](#5-resource-monitoring)
 
 ---
 
@@ -145,101 +144,7 @@ export const stripAnsiCodes = (text: string): string => { ... }
 
 ---
 
-## 3. Keyboard Shortcuts Reference
-
-**Priority:** Medium
-**Complexity:** Low
-**Feature:** Display a modal showing all available keyboard shortcuts
-
-### User Story
-
-As a user, I want to see all available keyboard shortcuts so that I can work more efficiently without using the mouse.
-
-### Current Shortcuts (to document)
-
-- `Cmd/Ctrl + F` - Focus search in log drawer
-- `Escape` - Close log drawer / Close modal
-- `Enter` - Next search result (in log drawer)
-- `Shift + Enter` - Previous search result (in log drawer)
-
-### UI Design
-
-- Trigger: `Cmd/Ctrl + ?` or `Cmd/Ctrl + /`
-- Alternative: Help menu item "Keyboard Shortcuts"
-- Modal with grouped shortcuts in a clean table format
-
-### Implementation Details
-
-#### Files to Create
-
-1. **`src/components/ui/KeyboardShortcutsModal.tsx`**
-   - Modal component displaying shortcuts in grouped sections
-   - Sections: "General", "Log Drawer", "Navigation"
-   - Render keyboard keys with styled `<kbd>` elements
-
-#### Files to Modify
-
-1. **`src/components/layout/BaseLayout.tsx`** or **`src/App.tsx`**
-   - Add global keyboard listener for `Cmd/Ctrl + ?`
-   - Manage modal open state
-
-2. **`src/components/layout/NavBar.tsx`** (optional)
-   - Add help icon button that opens the modal
-
-3. **`src/index.css`** (if needed)
-   - Style `<kbd>` elements to look like keyboard keys
-
-#### Shortcuts Data Structure
-
-```typescript
-// src/constants/keyboardShortcuts.ts
-export const KEYBOARD_SHORTCUTS = {
-  general: [
-    { keys: ['Cmd', '?'], description: 'Show keyboard shortcuts' },
-    { keys: ['Cmd', 'O'], description: 'Open config file' },
-  ],
-  logDrawer: [
-    { keys: ['Cmd', 'F'], description: 'Focus search' },
-    { keys: ['Escape'], description: 'Close drawer' },
-    { keys: ['Enter'], description: 'Next search result' },
-    { keys: ['Shift', 'Enter'], description: 'Previous search result' },
-  ],
-  dashboard: [
-    { keys: ['Cmd', 'Shift', 'S'], description: 'Stop all processes' },
-  ],
-};
-```
-
-#### Component Structure
-
-```tsx
-<Modal open={showShortcuts()} onClose={() => setShowShortcuts(false)}>
-  <h2>Keyboard Shortcuts</h2>
-  <For each={Object.entries(KEYBOARD_SHORTCUTS)}>
-    {([section, shortcuts]) => (
-      <section>
-        <h3>{formatSectionName(section)}</h3>
-        <For each={shortcuts}>
-          {(shortcut) => (
-            <div class="shortcut-row">
-              <span class="keys">
-                <For each={shortcut.keys}>
-                  {(key) => <kbd>{key}</kbd>}
-                </For>
-              </span>
-              <span class="description">{shortcut.description}</span>
-            </div>
-          )}
-        </For>
-      </section>
-    )}
-  </For>
-</Modal>
-```
-
----
-
-## 4. Process Grouping/Tags
+## 3. Process Grouping/Tags
 
 **Priority:** Medium
 **Complexity:** Medium
@@ -337,7 +242,7 @@ const groupProcesses = (processes: ProcessConfig[]): GroupedProcesses => {
 
 ---
 
-## 5. Settings/Preferences Panel
+## 4. Settings/Preferences Panel
 
 **Priority:** Medium
 **Complexity:** Medium
@@ -443,7 +348,7 @@ type Settings = {
 
 ---
 
-## 6. Resource Monitoring
+## 5. Resource Monitoring
 
 **Priority:** Medium
 **Complexity:** High
@@ -552,10 +457,9 @@ Suggested implementation order based on value and dependencies:
 
 1. **Environment Variables UI** - Medium effort, completes env vars feature
 2. **Log Export** - Low effort, frequently requested
-3. **Keyboard Shortcuts Reference** - Low effort, improves discoverability
-4. **Settings Panel** - Medium effort, enables other features
-5. **Process Grouping** - Medium effort, helps larger projects
-6. **Resource Monitoring** - High effort, nice to have
+3. **Settings Panel** - Medium effort, enables other features
+4. **Process Grouping** - Medium effort, helps larger projects
+5. **Resource Monitoring** - High effort, nice to have
 
 ---
 

--- a/src/features/dashboard/components/KeyboardShortcutsModal.tsx
+++ b/src/features/dashboard/components/KeyboardShortcutsModal.tsx
@@ -1,37 +1,17 @@
-import { X } from "lucide-solid";
-import { For } from "solid-js";
+import { Keyboard } from "lucide-solid";
+import { For, Show } from "solid-js";
 
 type Shortcut = {
   keys: string[];
   description: string;
 };
 
-type ShortcutGroup = {
-  title: string;
-  shortcuts: Shortcut[];
-};
-
-const isMac = navigator.userAgent.includes("Mac");
-const modKey = isMac ? "⌘" : "Ctrl";
-
-const SHORTCUT_GROUPS: ShortcutGroup[] = [
-  {
-    title: "General",
-    shortcuts: [
-      { keys: [modKey, "/"], description: "Show keyboard shortcuts" },
-      { keys: ["F5"], description: "Reload configuration" },
-      { keys: [modKey, "R"], description: "Reload configuration" },
-    ],
-  },
-  {
-    title: "Log Drawer",
-    shortcuts: [
-      { keys: [modKey, "F"], description: "Focus search" },
-      { keys: ["Escape"], description: "Close drawer" },
-      { keys: ["Enter"], description: "Next search result" },
-      { keys: ["Shift", "Enter"], description: "Previous search result" },
-    ],
-  },
+const SHORTCUTS: Shortcut[] = [
+  { keys: ["⌘", "/"], description: "Show shortcuts" },
+  { keys: ["⌘", "F"], description: "Focus search" },
+  { keys: ["Enter"], description: "Next search result" },
+  { keys: ["Shift", "Enter"], description: "Previous search result" },
+  { keys: ["Escape"], description: "Close drawer/shortcuts" },
 ];
 
 type KeyboardShortcutsModalProps = {
@@ -48,63 +28,52 @@ export const KeyboardShortcutsModal = (props: KeyboardShortcutsModalProps) => {
 
   return (
     <div
+      class={`modal modal-middle ${props.isOpen ? "modal-open" : ""}`}
       role="dialog"
       aria-modal="true"
       aria-label="Keyboard shortcuts"
-      class={`absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-200 ${
-        props.isOpen
-          ? "opacity-100 pointer-events-auto"
-          : "opacity-0 pointer-events-none"
-      }`}
-      style={{ "background-color": "rgba(0, 0, 0, 0.6)" }}
       onClick={handleBackdropClick}
     >
-      <div class="bg-base-100 rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-lg font-bold m-0!">Keyboard Shortcuts</h2>
-          <button
-            type="button"
-            class="btn btn-ghost btn-circle btn-sm"
-            onClick={props.onClose}
-          >
-            <X size={16} />
-          </button>
-        </div>
-        <div class="space-y-4">
-          <For each={SHORTCUT_GROUPS}>
-            {(group) => (
-              <div>
-                <h3 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider mb-2">
-                  {group.title}
-                </h3>
-                <div class="space-y-1">
-                  <For each={group.shortcuts}>
-                    {(shortcut) => (
-                      <div class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-base-200">
-                        <span class="text-sm">{shortcut.description}</span>
-                        <div class="flex items-center gap-1">
-                          <For each={shortcut.keys}>
-                            {(key, index) => (
-                              <>
-                                <kbd class="kbd kbd-sm">{key}</kbd>
-                                {index() < shortcut.keys.length - 1 && (
-                                  <span class="text-base-content/40 text-xs">
-                                    +
-                                  </span>
-                                )}
-                              </>
-                            )}
-                          </For>
-                        </div>
-                      </div>
+      <div class="modal-box max-w-sm">
+        <button
+          type="button"
+          class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          onClick={props.onClose}
+        >
+          ✕
+        </button>
+        <h3 class="font-bold text-lg flex items-center gap-2 mt-0!">
+          <Keyboard size={20} />
+          Shortcuts
+        </h3>
+        <div class="pt-4 space-y-2">
+          <For each={SHORTCUTS}>
+            {(shortcut) => (
+              <div class="flex items-center justify-between">
+                <span class="text-sm">{shortcut.description}</span>
+                <span class="flex items-center gap-1">
+                  <For each={shortcut.keys}>
+                    {(key, index) => (
+                      <>
+                        <kbd class="kbd kbd-sm">{key}</kbd>
+                        <Show when={index() < shortcut.keys.length - 1}>
+                          <span class="text-base-content/40 text-xs">+</span>
+                        </Show>
+                      </>
                     )}
                   </For>
-                </div>
+                </span>
               </div>
             )}
           </For>
         </div>
       </div>
+      <button
+        type="button"
+        class="modal-backdrop"
+        onClick={props.onClose}
+        aria-label="Close modal"
+      />
     </div>
   );
 };

--- a/src/features/dashboard/components/KeyboardShortcutsModal.tsx
+++ b/src/features/dashboard/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,110 @@
+import { X } from "lucide-solid";
+import { For } from "solid-js";
+
+type Shortcut = {
+  keys: string[];
+  description: string;
+};
+
+type ShortcutGroup = {
+  title: string;
+  shortcuts: Shortcut[];
+};
+
+const isMac = navigator.userAgent.includes("Mac");
+const modKey = isMac ? "⌘" : "Ctrl";
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    title: "General",
+    shortcuts: [
+      { keys: [modKey, "/"], description: "Show keyboard shortcuts" },
+      { keys: ["F5"], description: "Reload configuration" },
+      { keys: [modKey, "R"], description: "Reload configuration" },
+    ],
+  },
+  {
+    title: "Log Drawer",
+    shortcuts: [
+      { keys: [modKey, "F"], description: "Focus search" },
+      { keys: ["Escape"], description: "Close drawer" },
+      { keys: ["Enter"], description: "Next search result" },
+      { keys: ["Shift", "Enter"], description: "Previous search result" },
+    ],
+  },
+];
+
+type KeyboardShortcutsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const KeyboardShortcutsModal = (props: KeyboardShortcutsModalProps) => {
+  const handleBackdropClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      props.onClose();
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      class={`absolute inset-0 z-50 flex items-center justify-center transition-opacity duration-200 ${
+        props.isOpen
+          ? "opacity-100 pointer-events-auto"
+          : "opacity-0 pointer-events-none"
+      }`}
+      style={{ "background-color": "rgba(0, 0, 0, 0.6)" }}
+      onClick={handleBackdropClick}
+    >
+      <div class="bg-base-100 rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-bold m-0!">Keyboard Shortcuts</h2>
+          <button
+            type="button"
+            class="btn btn-ghost btn-circle btn-sm"
+            onClick={props.onClose}
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div class="space-y-4">
+          <For each={SHORTCUT_GROUPS}>
+            {(group) => (
+              <div>
+                <h3 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider mb-2">
+                  {group.title}
+                </h3>
+                <div class="space-y-1">
+                  <For each={group.shortcuts}>
+                    {(shortcut) => (
+                      <div class="flex items-center justify-between py-1.5 px-2 rounded hover:bg-base-200">
+                        <span class="text-sm">{shortcut.description}</span>
+                        <div class="flex items-center gap-1">
+                          <For each={shortcut.keys}>
+                            {(key, index) => (
+                              <>
+                                <kbd class="kbd kbd-sm">{key}</kbd>
+                                {index() < shortcut.keys.length - 1 && (
+                                  <span class="text-base-content/40 text-xs">
+                                    +
+                                  </span>
+                                )}
+                              </>
+                            )}
+                          </For>
+                        </div>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </div>
+            )}
+          </For>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/dashboard/components/ProcessLogDrawer.tsx
+++ b/src/features/dashboard/components/ProcessLogDrawer.tsx
@@ -651,10 +651,10 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
         </div>
 
         {/* Keyboard shortcuts hint */}
-        <div class="px-4 py-1.5 border-t border-base-300 flex justify-end">
+        <div class="border-t border-base-300 flex justify-end px-1">
           <button
             type="button"
-            class="flex items-center gap-1.5 text-xs text-base-content/50 hover:text-base-content/80 transition-colors cursor-pointer"
+            class="btn btn-ghost btn-xs text-base-content/50"
             onClick={() => setShowShortcuts(true)}
           >
             <kbd class="kbd kbd-xs">⌘</kbd>

--- a/src/features/dashboard/components/ProcessLogDrawer.tsx
+++ b/src/features/dashboard/components/ProcessLogDrawer.tsx
@@ -24,6 +24,7 @@ import type { ProcessLogData } from "@/electron/types";
 import { isLiveUpdate } from "@/utils/ansiToHtml";
 import { useDashboardContext } from "../contexts";
 import { ProcessStatus } from "../enums";
+import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import { PlayStopButton } from "./PlayStopButton";
 import { ProcessLogRow } from "./ProcessLogRow";
 
@@ -53,6 +54,7 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
   });
   const [isAtBottom, setIsAtBottom] = createSignal(true);
   const [selectedLogId, setSelectedLogId] = createSignal<string | null>(null);
+  const [showShortcuts, setShowShortcuts] = createSignal(false);
 
   let searchTimer: number | null = null;
   const [searchValue, setSearchValue] = createSignal<string | undefined>("");
@@ -265,6 +267,10 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
   /* Exits the drawer on "Escape" key if the drawer is open and the search input is not focused */
   const handleEscape = (e: KeyboardEvent) => {
     if (e.key !== "Escape" || !props.isOpen) return;
+    if (showShortcuts()) {
+      setShowShortcuts(false);
+      return;
+    }
     const activeElement = document.activeElement;
     if (activeElement === searchInputRef) return;
     props.onClose();
@@ -279,9 +285,17 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
     searchInputRef.focus();
   };
 
+  /* Toggles the keyboard shortcuts modal on CMD/Ctrl + / */
+  const handleShortcutsToggle = (e: KeyboardEvent) => {
+    if (e.key !== "/" || !(e.metaKey || e.ctrlKey) || !props.isOpen) return;
+    e.preventDefault();
+    setShowShortcuts((prev) => !prev);
+  };
+
   const handleKeyDown = (e: KeyboardEvent) => {
     handleEscape(e);
     handleCmdF(e);
+    handleShortcutsToggle(e);
   };
 
   // Auto-scroll to bottom when logs are rendered
@@ -411,7 +425,7 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
         onClick={props.onClose}
         aria-label="Close drawer"
       />
-      <div class="w-[95vw] h-full bg-base-100 flex flex-col pt-6">
+      <div class="w-[95vw] h-full bg-base-100 flex flex-col pt-6 relative">
         {/* Header */}
         <div class="px-4 py-2 border-b border-base-300">
           <div class="flex flex-row items-center gap-2">
@@ -635,6 +649,25 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
             </button>
           </Show>
         </div>
+
+        {/* Keyboard shortcuts hint */}
+        <div class="px-4 py-1.5 border-t border-base-300 flex justify-end">
+          <button
+            type="button"
+            class="flex items-center gap-1.5 text-xs text-base-content/50 hover:text-base-content/80 transition-colors cursor-pointer"
+            onClick={() => setShowShortcuts(true)}
+          >
+            <kbd class="kbd kbd-xs">⌘</kbd>
+            <kbd class="kbd kbd-xs">/</kbd>
+            <span>Shortcuts</span>
+          </button>
+        </div>
+
+        {/* Keyboard shortcuts modal overlay */}
+        <KeyboardShortcutsModal
+          isOpen={showShortcuts()}
+          onClose={() => setShowShortcuts(false)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Press Cmd/Ctrl + / while the log drawer is open to view all available
keyboard shortcuts in a modal overlay. Includes a clickable hint at
the bottom-right of the drawer using DaisyUI kbd components.
