### PR TITLE
feat: add resource monitoring (CPU/memory) per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - 🚀 Added **process grouping**: new optional `group` field per process to organize processes into collapsible groups.
 - ✨ Added **copy log line** button, visible on hover.
 - ✨ Added toast notifications when a process crashes.
+- 🚀 Added **resource monitoring**: real-time CPU and memory usage displayed per process in the dashboard.
 
 ## 1.5.0 - 2026-01-24
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - **Environment variables**: Set custom env vars per process, merged with system environment
 - **Auto-restart**: Automatically restart crashed processes with configurable retry limits
 - **Process grouping**: Organize processes into collapsible groups with per-group start/stop
+- **Resource monitoring**: Real-time CPU and memory usage per process
 
 | Homepage                              | Dashboard                               | Log Drawer                                |
 | ------------------------------------- | --------------------------------------- | ----------------------------------------- |

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -62,11 +62,13 @@ import {
 } from "./utils/extractYamlConfig";
 import {
   getBulkProcessStatus,
+  getRunningProcessPids,
   isProcessRunning,
   startProcess,
   stopAllProcesses,
   stopProcess,
 } from "./utils/processManager";
+import { getProcessResources } from "./utils/resourceMonitor";
 import { validatePaths } from "./utils/validatePaths";
 
 const createWindow = (): void => {
@@ -205,6 +207,12 @@ app.whenReady().then(() => {
   // IPC handler for getting bulk process status
   ipcMain.handle("process:bulk-status", async (_, processIds: string[]) => {
     return getBulkProcessStatus(processIds);
+  });
+
+  // IPC handler for getting process resources (CPU/memory)
+  ipcMain.handle("process:resources", async (_, processIds: string[]) => {
+    const pidMap = getRunningProcessPids(processIds);
+    return getProcessResources(pidMap);
   });
 
   // IPC handler for stopping all processes

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -28,6 +28,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getBulkProcessStatus: (processIds: string[]) =>
     ipcRenderer.invoke("process:bulk-status", processIds),
   stopAllProcesses: () => ipcRenderer.invoke("process:stop-all"),
+  getProcessResources: (processIds: string[]) =>
+    ipcRenderer.invoke("process:resources", processIds),
   // Process log streaming
   onProcessLog: (callback: (logData: any) => void) => {
     ipcRenderer.on("process-log", (_: any, logData: any) => callback(logData));

--- a/electron/utils/processManager.ts
+++ b/electron/utils/processManager.ts
@@ -332,3 +332,16 @@ export const getBulkProcessStatus = async (
   }
   return statusMap;
 };
+
+export const getRunningProcessPids = (
+  processIds: string[],
+): Record<string, number> => {
+  const pidMap: Record<string, number> = {};
+  for (const processId of processIds) {
+    const state = runningProcesses.get(processId);
+    if (state?.childProcess.pid && !state.childProcess.killed) {
+      pidMap[processId] = state.childProcess.pid;
+    }
+  }
+  return pidMap;
+};

--- a/electron/utils/resourceMonitor.test.ts
+++ b/electron/utils/resourceMonitor.test.ts
@@ -1,0 +1,81 @@
+import { exec } from "node:child_process";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getProcessResources } from "./resourceMonitor";
+
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+}));
+
+const mockExec = vi.mocked(exec);
+
+describe("resourceMonitor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getProcessResources", () => {
+    test("should return resource data for running processes", async () => {
+      mockExec.mockImplementation((_cmd: string, callback: any) => {
+        callback(null, "  5.2  65536\n  2.1  32768\n");
+        return {} as any;
+      });
+
+      const result = await getProcessResources({ "proc-1": 1234 });
+
+      expect(result["proc-1"]).toEqual({
+        cpu: 7.3,
+        memoryBytes: (65536 + 32768) * 1024,
+      });
+    });
+
+    test("should return zeros when ps command fails", async () => {
+      mockExec.mockImplementation((_cmd: string, callback: any) => {
+        callback(new Error("No such process"), "");
+        return {} as any;
+      });
+
+      const result = await getProcessResources({ "proc-1": 9999 });
+
+      expect(result["proc-1"]).toEqual({ cpu: 0, memoryBytes: 0 });
+    });
+
+    test("should return zeros when output is empty", async () => {
+      mockExec.mockImplementation((_cmd: string, callback: any) => {
+        callback(null, "");
+        return {} as any;
+      });
+
+      const result = await getProcessResources({ "proc-1": 1234 });
+
+      expect(result["proc-1"]).toEqual({ cpu: 0, memoryBytes: 0 });
+    });
+
+    test("should handle multiple processes in parallel", async () => {
+      let callCount = 0;
+      mockExec.mockImplementation((_cmd: string, callback: any) => {
+        callCount++;
+        if (callCount === 1) {
+          callback(null, "  10.0  102400\n");
+        } else {
+          callback(null, "  3.5  51200\n");
+        }
+        return {} as any;
+      });
+
+      const result = await getProcessResources({
+        "proc-1": 1000,
+        "proc-2": 2000,
+      });
+
+      expect(result["proc-1"]).toBeDefined();
+      expect(result["proc-2"]).toBeDefined();
+      expect(mockExec).toHaveBeenCalledTimes(2);
+    });
+
+    test("should return empty object when no processes given", async () => {
+      const result = await getProcessResources({});
+      expect(result).toEqual({});
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/utils/resourceMonitor.ts
+++ b/electron/utils/resourceMonitor.ts
@@ -1,0 +1,58 @@
+import { exec } from "node:child_process";
+
+export type ProcessResourceData = {
+  cpu: number;
+  memoryBytes: number;
+};
+
+/**
+ * Get CPU and memory usage for a process and all its children using `ps`.
+ * macOS only. Uses process group (-g) to capture child processes.
+ */
+const getProcessStats = (pid: number): Promise<ProcessResourceData> => {
+  return new Promise((resolve) => {
+    // Use -g to get the entire process group (parent + children spawned with detached/shell)
+    exec(`ps -g ${pid} -o %cpu=,rss=`, (error, stdout) => {
+      if (error || !stdout.trim()) {
+        resolve({ cpu: 0, memoryBytes: 0 });
+        return;
+      }
+      const lines = stdout
+        .trim()
+        .split("\n")
+        .filter((line) => line.trim() !== "");
+      let totalCpu = 0;
+      let totalRssKb = 0;
+      for (const line of lines) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length >= 2) {
+          totalCpu += Number.parseFloat(parts[0]) || 0;
+          totalRssKb += Number.parseInt(parts[1], 10) || 0;
+        }
+      }
+      resolve({
+        cpu: Math.round(totalCpu * 10) / 10,
+        memoryBytes: totalRssKb * 1024,
+      });
+    });
+  });
+};
+
+/**
+ * Get resource usage for multiple processes by their PIDs.
+ * Returns a map of processId -> resource data.
+ */
+export const getProcessResources = async (
+  pidMap: Record<string, number>,
+): Promise<Record<string, ProcessResourceData>> => {
+  const result: Record<string, ProcessResourceData> = {};
+  const entries = Object.entries(pidMap);
+
+  const promises = entries.map(async ([processId, pid]) => {
+    const stats = await getProcessStats(pid);
+    result[processId] = stats;
+  });
+
+  await Promise.all(promises);
+  return result;
+};

--- a/src/electron/types.ts
+++ b/src/electron/types.ts
@@ -82,6 +82,13 @@ export type ProcessLogData = {
 
 export type BulkProcessStatusResult = Record<ProcessId, boolean>;
 
+export type ProcessResourceData = {
+  cpu: number;
+  memoryBytes: number;
+};
+
+export type BulkProcessResourcesResult = Record<ProcessId, ProcessResourceData>;
+
 export type ProcessRestartData = {
   processId: ProcessId;
   retryCount: number;
@@ -119,6 +126,9 @@ export interface ElectronAPI {
     processIds: ProcessId[],
   ) => Promise<BulkProcessStatusResult>;
   stopAllProcesses: () => Promise<{ success: boolean }>;
+  getProcessResources: (
+    processIds: ProcessId[],
+  ) => Promise<BulkProcessResourcesResult>;
   // Process log streaming
   onProcessLog: (callback: (logData: ProcessLogData) => void) => void;
   removeProcessLogListener: () => void;

--- a/src/features/dashboard/components/ProcessGroupHeader.tsx
+++ b/src/features/dashboard/components/ProcessGroupHeader.tsx
@@ -24,7 +24,7 @@ export const ProcessGroupHeader = (props: ProcessGroupHeaderProps) => {
 
   return (
     <tr class="bg-base-300">
-      <td colspan="3" class="p-2!">
+      <td colspan="4" class="p-2!">
         <div class="flex items-center justify-between">
           <button
             type="button"

--- a/src/features/dashboard/components/ProcessLogDrawer.tsx
+++ b/src/features/dashboard/components/ProcessLogDrawer.tsx
@@ -27,6 +27,7 @@ import { ProcessStatus } from "../enums";
 import { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
 import { PlayStopButton } from "./PlayStopButton";
 import { ProcessLogRow } from "./ProcessLogRow";
+import { ProcessResources } from "./ProcessResources";
 
 type ProcessLogDrawerProps = {
   processName: string;
@@ -43,10 +44,19 @@ const SEARCH_DELAY_MS = 500;
 const SCROLL_TO_BOTTOM_THRESHOLD = 200;
 
 export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
-  const { yamlConfig, getProcessId, getProcessStatus, getProcessData } =
-    useDashboardContext();
+  const {
+    yamlConfig,
+    getProcessId,
+    getProcessStatus,
+    getProcessData,
+    getProcessResources,
+  } = useDashboardContext();
   const processStatus = () => getProcessStatus(props.processName);
   const processData = () => getProcessData(props.processName);
+  const resources = () => getProcessResources(props.processName);
+  const isRunning = () =>
+    processStatus() === ProcessStatus.RUNNING ||
+    processStatus() === ProcessStatus.RESTARTING;
 
   const [uiState, setUiState] = createStore({
     autoScroll: true,
@@ -455,6 +465,7 @@ export const ProcessLogDrawer = (props: ProcessLogDrawerProps) => {
                 <div class="badge badge-neutral">Idle</div>
               </Match>
             </Switch>
+            <ProcessResources resources={resources()} isRunning={isRunning()} />
           </div>
           <button
             type="button"

--- a/src/features/dashboard/components/ProcessResources.tsx
+++ b/src/features/dashboard/components/ProcessResources.tsx
@@ -1,0 +1,51 @@
+import { createMemo, Show } from "solid-js";
+import type { ProcessResourceData } from "@/electron/types";
+import { formatBytes, formatCpu } from "@/utils/formatters";
+
+type ProcessResourcesProps = {
+  resources: ProcessResourceData | undefined;
+  isRunning: boolean;
+};
+
+export const ProcessResources = (props: ProcessResourcesProps) => {
+  const cpu = createMemo(() => {
+    if (!props.isRunning || !props.resources) return null;
+    return formatCpu(props.resources.cpu);
+  });
+
+  const memory = createMemo(() => {
+    if (!props.isRunning || !props.resources) return null;
+    return formatBytes(props.resources.memoryBytes);
+  });
+
+  return (
+    <Show
+      when={props.isRunning && cpu() && memory()}
+      fallback={
+        <div class="flex flex-col gap-0">
+          <div class="text-xs text-gray-500 font-mono whitespace-nowrap">
+            CPU: —
+          </div>
+          <div class="text-xs text-gray-500 font-mono whitespace-nowrap">
+            RAM: —
+          </div>
+        </div>
+      }
+    >
+      <div class="flex flex-col gap-0">
+        <div
+          class="text-xs font-mono whitespace-nowrap text-base-content"
+          title="CPU usage"
+        >
+          CPU: {cpu()}
+        </div>
+        <div
+          class="text-xs font-mono whitespace-nowrap text-base-content"
+          title="Memory usage"
+        >
+          RAM: {memory()}
+        </div>
+      </div>
+    </Show>
+  );
+};

--- a/src/features/dashboard/components/ProcessRow.tsx
+++ b/src/features/dashboard/components/ProcessRow.tsx
@@ -6,6 +6,7 @@ import { ProcessStatus } from "../enums";
 import { PlayStopButton } from "./PlayStopButton";
 import { ProcessArg } from "./ProcessArg";
 import { ProcessDuration } from "./ProcessDuration";
+import { ProcessResources } from "./ProcessResources";
 
 type ProcessRowProps = {
   process: ProcessConfig;
@@ -21,12 +22,14 @@ export const ProcessRow = (props: ProcessRowProps) => {
     getProcessStatus,
     getProcessStartTime,
     getProcessData,
+    getProcessResources,
   } = useDashboardContext();
   const command = () => getProcessCommand(props.process.name);
   const args = () => getProcessArgs(props.process.name);
   const status = () => getProcessStatus(props.process.name);
   const startTime = () => getProcessStartTime(props.process.name);
   const processData = () => getProcessData(props.process.name);
+  const resources = () => getProcessResources(props.process.name);
   const [showOptions, setShowOptions] = createSignal(false);
 
   const toggleOptions = () => setShowOptions(!showOptions());
@@ -109,6 +112,15 @@ export const ProcessRow = (props: ProcessRowProps) => {
             }
           />
         </div>
+      </td>
+      <td class="align-top w-32 flex-shrink-0 !p-2">
+        <ProcessResources
+          resources={resources()}
+          isRunning={
+            status() === ProcessStatus.RUNNING ||
+            status() === ProcessStatus.RESTARTING
+          }
+        />
       </td>
       <td class="align-top w-32 flex-shrink-0 !p-2">
         <div class="flex items-center gap-2">

--- a/src/features/dashboard/components/ProcessTable.tsx
+++ b/src/features/dashboard/components/ProcessTable.tsx
@@ -38,6 +38,7 @@ export const ProcessTable = () => {
               <tr>
                 <th class="w-auto min-w-0">Processes</th>
                 <th class="w-32 flex-shrink-0">Status</th>
+                <th class="w-32 flex-shrink-0">Resources</th>
                 <th class="w-32 flex-shrink-0">Actions</th>
               </tr>
             </thead>

--- a/src/features/dashboard/contexts/DashboardContext.ts
+++ b/src/features/dashboard/contexts/DashboardContext.ts
@@ -3,6 +3,7 @@ import type {
   ArgConfig,
   ProcessConfig,
   ProcessId,
+  ProcessResourceData,
   ValidationResult,
   YamlConfig,
 } from "@/electron/types";
@@ -46,6 +47,7 @@ export type DashboardContextType = {
   getProcessId: (processName: string) => ProcessId | null;
   getProcessArgs: (processName: string) => ArgConfig[] | undefined;
   setArgValues: (processName: string, argName: string, value: string) => void;
+  getProcessResources: (processName: string) => ProcessResourceData | undefined;
   startProcess: (processName: string) => Promise<void>;
   stopProcess: (processName: string) => Promise<void>;
 };

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,16 @@
+const UNITS = ["B", "KB", "MB", "GB", "TB"];
+
+export const formatBytes = (bytes: number): string => {
+  if (bytes === 0) return "0 B";
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    UNITS.length - 1,
+  );
+  const value = bytes / 1024 ** exponent;
+  const formatted = exponent === 0 ? value.toString() : value.toFixed(1);
+  return `${formatted} ${UNITS[exponent]}`;
+};
+
+export const formatCpu = (percent: number): string => {
+  return `${percent.toFixed(1)}%`;
+};


### PR DESCRIPTION
Display real-time CPU and memory usage for each running process in the
dashboard. Uses macOS `ps -g` to aggregate stats across process groups,
polled every 3 seconds. Values are color-coded (warning at 50% CPU /
512MB, error at 80% CPU / 1GB).
