### PR TITLE
fix: hide homepage button on the welcome page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - 🔧 Others
 - 💥 Breaking
 
+## Unreleased
+
+- 🐞 Hide the homepage button on the welcome page where it serves no purpose.
+
 ## 2.0.2 - 2026-02-23
 
 - 🐞 Fixed bug where you could not upgrade to the latest version.

--- a/TODO.md
+++ b/TODO.md
@@ -14,8 +14,7 @@ Feature ideas worth implementing:
 4. Feat: Only show active processes (on the dashboard)
 5. Feat: Add a "Go back" button on the dashboard to go back to homepage. Same behavior as the Homepage button in the header (with the warning modal)
 6. Fix: Clicking on the homepage button (or go back) shouldn't prompt the warning modal if no processes are running
-7. Fix: Do not show the homepage button on the welcome page
-8. Update deps
+7. Update deps
 
 ---
 

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,7 +1,7 @@
 import { ProcessService } from "@backend";
 import { useLocation, useNavigate } from "@solidjs/router";
 import { House, Settings } from "lucide-solid";
-import { createSignal } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { SettingsModal } from "@/features/settings/components";
 import { routePaths } from "@/routes";
 import { Logo } from "../ui/Logo";
@@ -43,15 +43,17 @@ export const NavBar = () => {
               <Settings size={18} />
             </button>
           </div>
-          <div class="tooltip tooltip-left" data-tip="Homepage">
-            <button
-              type="button"
-              class="btn btn-ghost btn-circle btn-sm no-drag"
-              onClick={onHomeButtonClick}
-            >
-              <House size={20} />
-            </button>
-          </div>
+          <Show when={location.pathname !== routePaths.projectSelection}>
+            <div class="tooltip tooltip-left" data-tip="Homepage">
+              <button
+                type="button"
+                class="btn btn-ghost btn-circle btn-sm no-drag"
+                onClick={onHomeButtonClick}
+              >
+                <House size={20} />
+              </button>
+            </div>
+          </Show>
         </div>
       </div>
       <Modal ref={modalRef!} onConfirm={handleConfirm} closable={true}>


### PR DESCRIPTION
## Summary
- Hide the homepage (House icon) button in the NavBar when on the welcome/project-selection page, where it served no purpose
- Wrap the button in a SolidJS `<Show>` conditional using the existing route check
- Update TODO.md and CHANGELOG.md

## Test plan
- [ ] On the welcome page, verify the House icon is not visible in the navbar
- [ ] Navigate to the dashboard, verify the House icon appears and triggers the confirmation modal
- [ ] Confirm the Settings icon remains visible on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)