### PR TITLE
feat: add Go back button on dashboard

### DIFF
--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,28 +1,14 @@
-import { ProcessService } from "@backend";
-import { useLocation, useNavigate } from "@solidjs/router";
+import { useLocation } from "@solidjs/router";
 import { House, Settings } from "lucide-solid";
 import { createSignal, Show } from "solid-js";
 import { SettingsModal } from "@/features/settings/components";
 import { routePaths } from "@/routes";
+import { GoHomeButton } from "../ui/GoHomeButton";
 import { Logo } from "../ui/Logo";
-import { Modal } from "../ui/Modal";
 
 export const NavBar = () => {
-  let modalRef!: HTMLDialogElement;
   const location = useLocation();
-  const navigate = useNavigate();
   const [showSettings, setShowSettings] = createSignal(false);
-
-  const handleConfirm = async () => {
-    await ProcessService.StopAll();
-    navigate(routePaths.projectSelection);
-  };
-
-  const onHomeButtonClick = () => {
-    if (location.pathname !== routePaths.projectSelection) {
-      modalRef?.showModal();
-    }
-  };
 
   return (
     <>
@@ -45,21 +31,11 @@ export const NavBar = () => {
           </div>
           <Show when={location.pathname !== routePaths.projectSelection}>
             <div class="tooltip tooltip-left" data-tip="Homepage">
-              <button
-                type="button"
-                class="btn btn-ghost btn-circle btn-sm no-drag"
-                onClick={onHomeButtonClick}
-              >
-                <House size={20} />
-              </button>
+              <GoHomeButton icon={House} size={20} class="no-drag" />
             </div>
           </Show>
         </div>
       </div>
-      <Modal ref={modalRef!} onConfirm={handleConfirm} closable={true}>
-        <h1 class="text-xl font-bold">Return to project selection?</h1>
-        <p>Any ongoing processes will be shut down.</p>
-      </Modal>
       <SettingsModal
         isOpen={showSettings()}
         onClose={() => setShowSettings(false)}

--- a/src/components/ui/GoHomeButton.tsx
+++ b/src/components/ui/GoHomeButton.tsx
@@ -1,0 +1,37 @@
+import { ProcessService } from "@backend";
+import { useNavigate } from "@solidjs/router";
+import type { LucideIcon } from "lucide-solid";
+import { routePaths } from "@/routes";
+import { Modal } from "./Modal";
+
+type GoHomeButtonProps = {
+  icon: LucideIcon;
+  size: number;
+  class?: string;
+};
+
+export const GoHomeButton = (props: GoHomeButtonProps) => {
+  let modalRef!: HTMLDialogElement;
+  const navigate = useNavigate();
+
+  const handleConfirm = async () => {
+    await ProcessService.StopAll();
+    navigate(routePaths.projectSelection);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        class={`btn btn-ghost btn-sm btn-circle ${props.class ?? ""}`}
+        onClick={() => modalRef?.showModal()}
+      >
+        <props.icon size={props.size} />
+      </button>
+      <Modal ref={modalRef!} onConfirm={handleConfirm} closable={true}>
+        <h1 class="text-xl font-bold">Return to project selection?</h1>
+        <p>Any ongoing processes will be shut down.</p>
+      </Modal>
+    </>
+  );
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export { ErrorFallback } from "./ErrorFallback";
 export { FadeIn } from "./FadeIn";
+export { GoHomeButton } from "./GoHomeButton";
 export { LoadingRing } from "./LoadingRing";
 export { Logo } from "./Logo";
 export { Modal } from "./Modal";

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { ProcessService } from "@backend";
 import { useNavigate, useSearchParams } from "@solidjs/router";
-import { Square } from "lucide-solid";
+import { ArrowLeft, Square } from "lucide-solid";
 import {
   createEffect,
   createMemo,
@@ -11,7 +11,7 @@ import {
   Switch,
 } from "solid-js";
 import { BaseLayout, HeroLayout } from "@/components/layout";
-import { LoadingRing, Modal, ScreenTitle } from "@/components/ui";
+import { GoHomeButton, LoadingRing, Modal, ScreenTitle } from "@/components/ui";
 import { useToast } from "@/hooks";
 import { routePaths } from "@/routes";
 import { ErrorList, ProcessTable } from "../components";
@@ -90,13 +90,17 @@ const Dashboard = () => {
         </Match>
         <Match when={errors().length > 0}>
           <BaseLayout>
-            <ScreenTitle title="Dashboard" />
+            <div class="flex flex-row gap-2 items-center">
+              <GoHomeButton icon={ArrowLeft} size={20} />
+              <ScreenTitle title="Dashboard" />
+            </div>
             <ErrorList />
           </BaseLayout>
         </Match>
         <Match when={!isLoading() && errors().length === 0}>
           <BaseLayout>
             <div class="flex flex-row gap-2 items-center">
+              <GoHomeButton icon={ArrowLeft} size={20} />
               <ScreenTitle
                 title={`Dashboard for ${yamlConfig()!.project_name}`}
               />


### PR DESCRIPTION
## Summary
- Add a reusable `GoHomeButton` component that encapsulates the warning modal + stop-all-processes + navigate-home logic
- Add a "Go back" (ArrowLeft) button next to the Dashboard title (both error and success states)
- Refactor NavBar to use `GoHomeButton` with a House icon, conditionally hidden on the welcome page

## Test plan
- [ ] On the dashboard, click the back arrow → warning modal appears → confirm stops processes and navigates home
- [ ] On the dashboard, click the House icon in the header → same behavior as the back arrow
- [ ] On the project selection page, the House icon in the header is hidden
- [ ] Cancel on either modal dismisses it without side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)