### PR TITLE
feat: skip warning modal when navigating home with no processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Unreleased
 
+- 🚀 Add a "Go back" button on the dashboard to return to project selection.
+- ✨ Skip the warning modal when navigating home with no running processes.
 - 🐞 Hide the homepage button on the welcome page where it serves no purpose.
 - 🔧 Upgraded all JS and Go dependencies to latest versions.
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,7 @@ Feature ideas worth implementing:
 2. Feat: Drag-and-drop process reordering: Allow reordering processes via drag and drop on the dashboard. With groups enabled: reorder groups relative to each other, and reorder processes within a group. Without groups: reorder the flat list freely. Persist the custom order in localStorage per project (keyed by config file path). Handle config changes gracefully — new processes appear at the end, removed processes are pruned from the saved order.
 3. Fix: emptying the logs should empty the search bar
 4. Feat: Only show active processes (on the dashboard)
-5. Feat: Add a "Go back" button on the dashboard to go back to homepage. Same behavior as the Homepage button in the header (with the warning modal)
-6. Fix: Clicking on the homepage button (or go back) shouldn't prompt the warning modal if no processes are running
+5. Update deps
 
 ---
 

--- a/src/components/ui/GoHomeButton.tsx
+++ b/src/components/ui/GoHomeButton.tsx
@@ -1,6 +1,8 @@
 import { ProcessService } from "@backend";
 import { useNavigate } from "@solidjs/router";
 import type { LucideIcon } from "lucide-solid";
+import { useContext } from "solid-js";
+import { DashboardContext } from "@/features/dashboard/contexts/DashboardContext";
 import { routePaths } from "@/routes";
 import { Modal } from "./Modal";
 
@@ -13,10 +15,19 @@ type GoHomeButtonProps = {
 export const GoHomeButton = (props: GoHomeButtonProps) => {
   let modalRef!: HTMLDialogElement;
   const navigate = useNavigate();
+  const dashboard = useContext(DashboardContext);
 
-  const handleConfirm = async () => {
+  const goHome = async () => {
     await ProcessService.StopAll();
     navigate(routePaths.projectSelection);
+  };
+
+  const handleClick = () => {
+    if (dashboard?.hasRunningProcesses()) {
+      modalRef?.showModal();
+    } else {
+      goHome();
+    }
   };
 
   return (
@@ -24,11 +35,11 @@ export const GoHomeButton = (props: GoHomeButtonProps) => {
       <button
         type="button"
         class={`btn btn-ghost btn-sm btn-circle ${props.class ?? ""}`}
-        onClick={() => modalRef?.showModal()}
+        onClick={handleClick}
       >
         <props.icon size={props.size} />
       </button>
-      <Modal ref={modalRef!} onConfirm={handleConfirm} closable={true}>
+      <Modal ref={modalRef!} onConfirm={goHome} closable={true}>
         <h1 class="text-xl font-bold">Return to project selection?</h1>
         <p>Any ongoing processes will be shut down.</p>
       </Modal>


### PR DESCRIPTION
## Summary
- GoHomeButton now checks `DashboardContext` for running processes and skips the confirmation modal when none are active, navigating directly home instead.
- Updates CHANGELOG and TODO to reflect both the previously completed "Go back" button feature and this modal-skip improvement.

## Test plan
- [ ] On the dashboard with running processes, click "Go back" or the navbar home button — confirmation modal should appear
- [ ] On the dashboard with no running processes, click either button — should navigate home immediately without modal
- [ ] Verify the error state dashboard (with GoHomeButton) also navigates home without modal when no processes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)