### PR TITLE
feat: add Active only toggle to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ## Unreleased
 
-- 🚀 Add a "Go back" button on the dashboard to return to project selection.
+- ✨ Add a "Hide idle" toggle on the dashboard to filter out stopped processes.
+- ✨ Add a "Go back" button on the dashboard to return to project selection.
 - ✨ Skip the warning modal when navigating home with no running processes.
 - 🐞 Hide the homepage button on the welcome page where it serves no purpose.
 - 🔧 Upgraded all JS and Go dependencies to latest versions.

--- a/TODO.md
+++ b/TODO.md
@@ -11,8 +11,7 @@ Feature ideas worth implementing:
 1. Allow displaying logs of multiple processes simultaneously
 2. Feat: Drag-and-drop process reordering: Allow reordering processes via drag and drop on the dashboard. With groups enabled: reorder groups relative to each other, and reorder processes within a group. Without groups: reorder the flat list freely. Persist the custom order in localStorage per project (keyed by config file path). Handle config changes gracefully — new processes appear at the end, removed processes are pruned from the saved order.
 3. Fix: emptying the logs should empty the search bar
-4. Feat: Only show active processes (on the dashboard)
-5. Update deps
+4. Update deps
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@ Feature ideas worth implementing:
 1. Allow displaying logs of multiple processes simultaneously
 2. Feat: Drag-and-drop process reordering: Allow reordering processes via drag and drop on the dashboard. With groups enabled: reorder groups relative to each other, and reorder processes within a group. Without groups: reorder the flat list freely. Persist the custom order in localStorage per project (keyed by config file path). Handle config changes gracefully — new processes appear at the end, removed processes are pruned from the saved order.
 3. Fix: emptying the logs should empty the search bar
-4. Update deps
 
 ---
 

--- a/src/features/dashboard/components/ProcessTable.tsx
+++ b/src/features/dashboard/components/ProcessTable.tsx
@@ -1,20 +1,43 @@
-import { createSignal, For, Show } from "solid-js";
+import { createMemo, createSignal, For, Show } from "solid-js";
 import { useSettingsContext } from "@/contexts";
 import { useDashboardContext } from "../contexts";
+import { ProcessStatus } from "../enums";
 import { ProcessGroupHeader } from "./ProcessGroupHeader";
 import { ProcessLogDrawer } from "./ProcessLogDrawer";
 import { ProcessRow } from "./ProcessRow";
 import { ResourceDrawer } from "./ResourceDrawer";
 
-export const ProcessTable = () => {
-  const { rootDirectory, getGroupedProcesses, hasGroups, isGroupCollapsed } =
-    useDashboardContext();
+type ProcessTableProps = {
+  hideIdle: boolean;
+};
+
+export const ProcessTable = (props: ProcessTableProps) => {
+  const {
+    rootDirectory,
+    getGroupedProcesses,
+    hasGroups,
+    isGroupCollapsed,
+    getProcessStatus,
+  } = useDashboardContext();
   const { settings } = useSettingsContext();
   const [selectedProcessName, setSelectedProcessName] = createSignal<
     string | null
   >(null);
   const [selectedResourceProcessName, setSelectedResourceProcessName] =
     createSignal<string | null>(null);
+
+  const filteredGroups = createMemo(() => {
+    const groups = getGroupedProcesses();
+    if (!props.hideIdle) return groups;
+    return groups
+      .map((group) => ({
+        ...group,
+        processes: group.processes.filter(
+          (p) => getProcessStatus(p.name) !== ProcessStatus.STOPPED,
+        ),
+      }))
+      .filter((group) => group.processes.length > 0);
+  });
 
   let drawerCheckboxRef!: HTMLInputElement;
   let resourceDrawerCheckboxRef!: HTMLInputElement;
@@ -71,37 +94,51 @@ export const ProcessTable = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  <For each={getGroupedProcesses()}>
-                    {(group) => (
-                      <>
-                        <Show when={hasGroups() && settings().showGrouping}>
-                          <ProcessGroupHeader
-                            groupName={group.name}
-                            totalCount={group.processes.length}
-                          />
-                        </Show>
-                        <Show
-                          when={
-                            !hasGroups() ||
-                            !settings().showGrouping ||
-                            !isGroupCollapsed(group.name)
-                          }
+                  <Show
+                    when={filteredGroups().length > 0}
+                    fallback={
+                      <tr>
+                        <td
+                          colspan="4"
+                          class="text-center text-base-content/50 py-8"
                         >
-                          <For each={group.processes}>
-                            {(process, index) => (
-                              <ProcessRow
-                                process={process}
-                                index={index()}
-                                rootDirectory={rootDirectory()!}
-                                onOpenLogs={openModal}
-                                onOpenResourceDrawer={openResourceDrawer}
-                              />
-                            )}
-                          </For>
-                        </Show>
-                      </>
-                    )}
-                  </For>
+                          No active processes
+                        </td>
+                      </tr>
+                    }
+                  >
+                    <For each={filteredGroups()}>
+                      {(group) => (
+                        <>
+                          <Show when={hasGroups() && settings().showGrouping}>
+                            <ProcessGroupHeader
+                              groupName={group.name}
+                              totalCount={group.processes.length}
+                            />
+                          </Show>
+                          <Show
+                            when={
+                              !hasGroups() ||
+                              !settings().showGrouping ||
+                              !isGroupCollapsed(group.name)
+                            }
+                          >
+                            <For each={group.processes}>
+                              {(process, index) => (
+                                <ProcessRow
+                                  process={process}
+                                  index={index()}
+                                  rootDirectory={rootDirectory()!}
+                                  onOpenLogs={openModal}
+                                  onOpenResourceDrawer={openResourceDrawer}
+                                />
+                              )}
+                            </For>
+                          </Show>
+                        </>
+                      )}
+                    </For>
+                  </Show>
                 </tbody>
               </table>
             </div>

--- a/src/features/dashboard/pages/Dashboard.tsx
+++ b/src/features/dashboard/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Square } from "lucide-solid";
 import {
   createEffect,
   createMemo,
+  createSignal,
   Match,
   onCleanup,
   onMount,
@@ -50,6 +51,7 @@ const DashboardPage = () => {
 const Dashboard = () => {
   const { isLoading, errors, yamlConfig, hasRunningProcesses } =
     useDashboardContext();
+  const [hideIdle, setHideIdle] = createSignal(false);
   let modalRef!: HTMLDialogElement;
 
   const handleReloadConfirm = async () => {
@@ -117,8 +119,17 @@ const Dashboard = () => {
                   <Square size={16} />
                 </button>
               </Show>
+              <label class="flex items-center gap-1.5 text-sm cursor-pointer ml-auto">
+                <span class="text-base-content/60">Active only</span>
+                <input
+                  type="checkbox"
+                  class="toggle toggle-sm toggle-primary"
+                  checked={hideIdle()}
+                  onChange={() => setHideIdle(!hideIdle())}
+                />
+              </label>
             </div>
-            <ProcessTable />
+            <ProcessTable hideIdle={hideIdle()} />
           </BaseLayout>
         </Match>
       </Switch>


### PR DESCRIPTION
## Summary
- Adds an "Active only" toggle in the dashboard header that filters out stopped processes from the process table
- Crashed processes remain visible (they stopped without user consent)
- Shows a "No active processes" empty state when all processes are filtered out
- Updates CHANGELOG and removes completed TODO item

## Test plan
- [ ] Toggle "Active only" on — verify stopped processes are hidden
- [ ] Toggle "Active only" on — verify crashed processes remain visible
- [ ] Toggle "Active only" on with all processes stopped — verify empty state message appears
- [ ] Toggle "Active only" off — verify all processes reappear
- [ ] Verify toggle works correctly with group collapsing enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)