### PR TITLE
refactor: reactive resource polling in useResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - ✨ Skip the warning modal when navigating home with no running processes.
 - 🐞 Hide the homepage button on the welcome page where it serves no purpose.
 - 🐞 Keep search input value when clearing process logs.
+- 🔧 Refactored DashboardProvider: replaced mutable ref callback with a reactive `createEffect` in `useResources`, making inter-hook communication fully reactive.
 - 🔧 Upgraded all JS and Go dependencies to latest versions.
 
 ## 2.0.2 - 2026-02-23

--- a/TODO.md
+++ b/TODO.md
@@ -9,8 +9,8 @@ This document outlines planned improvements for Click-Launch, ordered by impact/
 Feature ideas worth implementing:
 
 1. Add frontend tests: Add `vitest` + `@solidjs/testing-library`. Focus on hooks with business logic (`useLogStore`, `useProcesses`, `useGrouping`) rather than UI components. Mock Wails bindings via simple object stubs.
-2. Bindings sync check: Add a Task command that runs `wails3 generate bindings` then `bun run tsc --noEmit`, and hook it into `task check` so CI catches `backend.d.ts` drift.
-3. Refactor mutable ref in DashboardProvider: Replace the `let onProcessStarted` mutable ref pattern with a shared signal (e.g., a counter signal) that `useProcesses` writes to and `useResources` watches via `createEffect`, making the inter-hook communication fully reactive.
+2. Per-feature error boundaries: Wrap each feature's root component in `<ErrorBoundary>` using the existing `ErrorFallback` component. Place boundaries in route definitions so each page catches its own errors independently, keeping the app shell intact.
+3. Bindings sync check: Add a Task command that runs `wails3 generate bindings` then `bun run tsc --noEmit`, and hook it into `task check` so CI catches `backend.d.ts` drift.
 4. Allow displaying logs of multiple processes simultaneously
 5. Drag-and-drop process reordering: Allow reordering processes via drag and drop on the dashboard. With groups enabled: reorder groups relative to each other, and reorder processes within a group. Without groups: reorder the flat list freely. Persist the custom order in localStorage per project (keyed by config file path). Handle config changes gracefully — new processes appear at the end, removed processes are pruned from the saved order.
 

--- a/src/features/dashboard/contexts/DashboardProvider.tsx
+++ b/src/features/dashboard/contexts/DashboardProvider.tsx
@@ -23,22 +23,14 @@ type DashboardProviderProps = {
 export const DashboardProvider = (props: DashboardProviderProps) => {
   const config = useConfig(props.selectedFile);
 
-  // Use a mutable ref so useProcesses can call startResourcePolling
-  // after useResources is initialized (avoids circular dependency)
-  let onProcessStarted = () => {};
-
   const processes = useProcesses({
     yamlConfig: config.yamlConfig,
     rootDirectory: config.rootDirectory,
-    onProcessStarted: () => onProcessStarted(),
   });
 
   const resources = useResources({
     processesData: processes.processesData,
   });
-
-  // Wire up the callback now that resources is available
-  onProcessStarted = resources.startResourcePolling;
 
   const grouping = useGrouping({
     yamlConfig: config.yamlConfig,

--- a/src/features/dashboard/hooks/useProcesses.ts
+++ b/src/features/dashboard/hooks/useProcesses.ts
@@ -18,13 +18,11 @@ const POLL_STATUS_INTERVAL_MS = 1000;
 type UseProcessesParams = {
   yamlConfig: () => YamlConfig | null;
   rootDirectory: () => string | null;
-  onProcessStarted?: () => void;
 };
 
 export const useProcesses = ({
   yamlConfig,
   rootDirectory,
-  onProcessStarted,
 }: UseProcessesParams) => {
   const toast = useToast();
 
@@ -221,7 +219,6 @@ export const useProcesses = ({
         maxRetries: processConfig.restart?.max_retries ?? 3,
       });
       startPolling();
-      onProcessStarted?.();
     } else {
       setProcessesData(processName, "status", ProcessStatus.STOPPED);
       toast.error(`Failed to start ${processName}`);

--- a/src/features/dashboard/hooks/useResources.ts
+++ b/src/features/dashboard/hooks/useResources.ts
@@ -1,5 +1,5 @@
 import { ProcessService, ResourceService } from "@backend";
-import { onCleanup } from "solid-js";
+import { createEffect, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
 import { useSettingsContext } from "@/contexts";
 import type {
@@ -92,6 +92,14 @@ export const useResources = ({ processesData }: UseResourcesParams) => {
     }, POLL_RESOURCES_INTERVAL_MS);
   };
 
+  // Reactively start polling when active processes appear
+  createEffect(() => {
+    const hasActive = Object.values(processesData).some((p) =>
+      isProcessActive(p.status),
+    );
+    if (hasActive) startResourcePolling();
+  });
+
   const getProcessResources = (
     processName: string,
   ): ProcessResourceData | undefined => {
@@ -107,6 +115,5 @@ export const useResources = ({ processesData }: UseResourcesParams) => {
   return {
     getProcessResources,
     getProcessResourceHistory,
-    startResourcePolling,
   };
 };


### PR DESCRIPTION
## Summary
- Replaced the mutable `let onProcessStarted` ref pattern in `DashboardProvider` with a reactive `createEffect` in `useResources`
- `useResources` now watches `processesData` for active processes and auto-starts resource polling, eliminating the need for cross-hook callback wiring
- Removed the `onProcessStarted` callback parameter from `useProcesses`

## Test plan
- [ ] Start a single process — CPU/memory charts should appear and update every ~3 seconds
- [ ] Start a second process while one is running — both should show resource data
- [ ] Stop all processes — resource data should stop updating
- [ ] Start a process again after all were stopped — resources should resume
- [ ] Restart a process — resources should keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)