### PR TITLE
chore: remove bindings sync check TODO, scope lint

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,9 @@ Feature ideas worth implementing:
 
 1. Add frontend tests: Add `vitest` + `@solidjs/testing-library`. Focus on hooks with business logic (`useLogStore`, `useProcesses`, `useGrouping`) rather than UI components. Mock Wails bindings via simple object stubs.
 2. Per-feature error boundaries: Wrap each feature's root component in `<ErrorBoundary>` using the existing `ErrorFallback` component. Place boundaries in route definitions so each page catches its own errors independently, keeping the app shell intact.
-3. Bindings sync check: Add a Task command that runs `wails3 generate bindings` then `bun run tsc --noEmit`, and hook it into `task check` so CI catches `backend.d.ts` drift.
-4. Refactor mutable ref in DashboardProvider: Replace the `let onProcessStarted` mutable ref pattern with a shared signal (e.g., a counter signal) that `useProcesses` writes to and `useResources` watches via `createEffect`, making the inter-hook communication fully reactive.
-5. Allow displaying logs of multiple processes simultaneously
-6. Drag-and-drop process reordering: Allow reordering processes via drag and drop on the dashboard. With groups enabled: reorder groups relative to each other, and reorder processes within a group. Without groups: reorder the flat list freely. Persist the custom order in localStorage per project (keyed by config file path). Handle config changes gracefully — new processes appear at the end, removed processes are pruned from the saved order.
+3. Refactor mutable ref in DashboardProvider: Replace the `let onProcessStarted` mutable ref pattern with a shared signal (e.g., a counter signal) that `useProcesses` writes to and `useResources` watches via `createEffect`, making the inter-hook communication fully reactive.
+4. Allow displaying logs of multiple processes simultaneously
+5. Drag-and-drop process reordering: Allow reordering processes via drag and drop on the dashboard. With groups enabled: reorder groups relative to each other, and reorder processes within a group. Without groups: reorder the flat list freely. Persist the custom order in localStorage per project (keyed by config file path). Handle config changes gracefully — new processes appear at the end, removed processes are pruned from the saved order.
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,7 +42,7 @@ tasks:
     cmds:
       - bun run biome:check
       - bun run tsc
-      - golangci-lint run
+      - golangci-lint run ./backend/...
 
   test:
     summary: Runs all tests


### PR DESCRIPTION
## Summary
- Removed "Bindings sync check" item from TODO list — CI complexity with Wails CLI installation makes it not worth pursuing
- Scoped `golangci-lint run` to `./backend/...` in Taskfile to match CI and avoid `main.go` embed failures when `dist/` doesn't exist

## Test plan
- [x] Pre-commit hook passes locally (`task check`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)