### PR TITLE
fix: correct setup instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@
 ```shell
 git config core.hooksPath .githooks
 bun install
-task dev
+go mod tidy
 ```
 
 ## Developer Commands


### PR DESCRIPTION
## Summary
- Replace `task dev` with `go mod tidy` in the setup section of CONTRIBUTING.md
- The setup instructions should list dependency installation steps, not the dev server command

## Test plan
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Follow setup instructions on a fresh clone to confirm they work

🤖 Generated with [Claude Code](https://claude.com/claude-code)