### PR TITLE
feat: add env_file support per process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ build/darwin/Assets.car
 
 # Lock files
 resources/infinite_process.lock
+
+# Docs
+docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Unreleased
 
+- 🚀 Add `env_file` support per process: load environment variables from a `.env` file, with explicit `env` values taking precedence.
 - ✨ Add a "Hide idle" toggle on the dashboard to filter out stopped processes.
 - ✨ Add a "Go back" button on the dashboard to return to project selection.
 - ✨ Skip the warning modal when navigating home with no running processes.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     - [Root Configuration](#root-configuration)
     - [Process Configuration](#process-configuration)
     - [Environment Variables Configuration](#environment-variables-configuration)
+    - [Env File Configuration](#env-file-configuration)
     - [Restart Configuration](#restart-configuration)
     - [Argument Configuration (All Types)](#argument-configuration-all-types)
     - [Toggle-Specific Configuration](#toggle-specific-configuration)
@@ -112,6 +113,7 @@ Create a `config.yml` file in your project directory to define your development 
 | `processes[].group`        | `string` | ❌       | Group name for organizing processes                                     | `"Backend"`              |
 | `processes[].cwd`          | `string` | ❌       | Working directory for the process (relative to config file or absolute) | `"./packages/api"`       |
 | `processes[].env`          | `object` | ❌       | Custom environment variables                                            | See env config below     |
+| `processes[].env_file`     | `string` | ❌       | Path to a `.env` file (relative to `cwd` or absolute)                   | `".env"`                 |
 | `processes[].restart`      | `object` | ❌       | Auto-restart configuration                                              | See restart config below |
 | `processes[].args`         | `array`  | ❌       | List of configurable arguments                                          | See argument types below |
 
@@ -135,6 +137,34 @@ processes:
 - If present, must be an object with string keys and string values
 - Empty string values are allowed (useful for declaring a variable exists)
 - Values override any existing system environment variables with the same name
+
+### Env File Configuration
+
+Load environment variables from a `.env` file. The file path is resolved relative to the process's working directory (`cwd`). Variables from the env file are loaded first, then any explicit `env` values override them.
+
+```yaml
+processes:
+  - name: "API Server"
+    base_command: "pnpm start"
+    cwd: "./packages/api"
+    env_file: ".env"
+    env:
+      NODE_ENV: development # overrides .env value if present
+```
+
+**Supported `.env` format:**
+
+- `KEY=VALUE` pairs, one per line
+- Lines starting with `#` are comments
+- Blank lines are ignored
+- Quoted values are unquoted (`"hello world"` → `hello world`)
+- `export KEY=VALUE` syntax is supported
+
+**Precedence** (highest to lowest):
+
+1. Explicit `env` values (from YAML config, editable in UI)
+2. `.env` file values
+3. System environment variables
 
 ### Process Grouping Configuration
 
@@ -204,6 +234,7 @@ processes:
   - name: "Web Server"
     group: "Frontend"
     base_command: "pnpm start"
+    env_file: ".env"
     restart:
       enabled: true
       max_retries: 3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 includes:
   common: ./build/Taskfile.yml
@@ -7,7 +7,7 @@ includes:
 vars:
   APP_NAME: "ClickLaunch"
   BIN_DIR: "bin"
-  VITE_PORT: '{{.WAILS_VITE_PORT | default 9245}}'
+  VITE_PORT: "{{.WAILS_VITE_PORT | default 9245}}"
 
 tasks:
   build:
@@ -33,7 +33,7 @@ tasks:
       - task: "darwin:run"
 
   dev:
-    summary: Runs the application in development mode
+    summary: Runs the application in development mode (use WAILS_VITE_PORT to override, e.g. WAILS_VITE_PORT=9246 task dev)
     cmds:
       - wails3 dev -config ./build/config.yml -port {{.VITE_PORT}}
 

--- a/backend/config_service.go
+++ b/backend/config_service.go
@@ -115,6 +115,9 @@ func validateProcess(raw any, basePath string, errors *[]ValidationError) {
 	if _, exists := process["cwd"]; exists {
 		validateString("cwd", process["cwd"], true, basePath, errors)
 	}
+	if _, exists := process["env_file"]; exists {
+		validateString("env_file", process["env_file"], true, basePath, errors)
+	}
 	if _, exists := process["env"]; exists {
 		validateEnvConfig(process["env"], basePath+".env", errors)
 	}

--- a/backend/config_service_test.go
+++ b/backend/config_service_test.go
@@ -150,6 +150,21 @@ var configTestCases = []configTestCase{
 		shouldBeValid:  true,
 	},
 	{
+		name:           "valid env_file config",
+		filename:       "valid-env-file-config.yml",
+		expectedErrors: []ValidationError{},
+		shouldBeValid:  true,
+	},
+	{
+		name:     "invalid env_file config (non-string and empty)",
+		filename: "invalid-env-file-config.yml",
+		expectedErrors: []ValidationError{
+			{Message: "env_file must be a non-empty string", Path: "processes[0]"},
+			{Message: "env_file must be a non-empty string", Path: "processes[1]"},
+		},
+		shouldBeValid: false,
+	},
+	{
 		name:     "invalid group config (non-string and empty)",
 		filename: "invalid-group-config.yml",
 		expectedErrors: []ValidationError{

--- a/backend/env_file.go
+++ b/backend/env_file.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"path/filepath"
+
+	"github.com/joho/godotenv"
+)
+
+// resolveEnvFilePath resolves an env file path relative to the process cwd.
+func resolveEnvFilePath(envFile string, cwd string) string {
+	if filepath.IsAbs(envFile) {
+		return envFile
+	}
+	return filepath.Join(cwd, envFile)
+}
+
+// parseEnvFile reads a .env file and returns key-value pairs.
+func parseEnvFile(path string) (map[string]string, error) {
+	return godotenv.Read(path)
+}

--- a/backend/env_file_test.go
+++ b/backend/env_file_test.go
@@ -1,0 +1,73 @@
+package backend
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseEnvFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses valid env file", func(t *testing.T) {
+		t.Parallel()
+		envMap, err := parseEnvFile(filepath.Join("testdata", "sample.env"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		expected := map[string]string{
+			"DB_HOST":      "localhost",
+			"DB_PORT":      "5432",
+			"APP_ENV":      "development",
+			"EMPTY_VALUE":  "",
+			"QUOTED_VALUE": "hello world",
+			"EXPORTED_VAR": "exported_value",
+		}
+		if len(envMap) != len(expected) {
+			t.Fatalf("got %d entries, want %d\ngot: %v", len(envMap), len(expected), envMap)
+		}
+		for k, want := range expected {
+			got, ok := envMap[k]
+			if !ok {
+				t.Errorf("missing key %q", k)
+			} else if got != want {
+				t.Errorf("key %q = %q, want %q", k, got, want)
+			}
+		}
+	})
+
+	t.Run("returns error for non-existent file", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseEnvFile("/non/existent/.env")
+		if err == nil {
+			t.Error("expected error for non-existent file, got nil")
+		}
+	})
+}
+
+func TestResolveEnvFilePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absolute path returned as-is", func(t *testing.T) {
+		t.Parallel()
+		got := resolveEnvFilePath("/absolute/.env", "/some/cwd")
+		if got != "/absolute/.env" {
+			t.Errorf("got %q, want %q", got, "/absolute/.env")
+		}
+	})
+
+	t.Run("relative path joined with cwd", func(t *testing.T) {
+		t.Parallel()
+		got := resolveEnvFilePath(".env", "/project/dir")
+		if got != "/project/dir/.env" {
+			t.Errorf("got %q, want %q", got, "/project/dir/.env")
+		}
+	})
+
+	t.Run("dot-slash relative path joined with cwd", func(t *testing.T) {
+		t.Parallel()
+		got := resolveEnvFilePath("./config/.env", "/project/dir")
+		if got != "/project/dir/config/.env" {
+			t.Errorf("got %q, want %q", got, "/project/dir/config/.env")
+		}
+	})
+}

--- a/backend/process_service.go
+++ b/backend/process_service.go
@@ -358,7 +358,7 @@ func extractExitInfo(cmd *exec.Cmd) (*int, *string) {
 // --- Exported methods (Wails bindings) ---
 
 // Start spawns a new process and returns its ID.
-func (s *ProcessService) Start(cwd string, command string, restartConfig *RestartConfig, env map[string]string) ProcessStartResult {
+func (s *ProcessService) Start(cwd string, command string, restartConfig *RestartConfig, env map[string]string, envFile string) ProcessStartResult {
 	if _, err := os.Stat(cwd); os.IsNotExist(err) {
 		return ProcessStartResult{
 			Success: false,
@@ -366,8 +366,28 @@ func (s *ProcessService) Start(cwd string, command string, restartConfig *Restar
 		}
 	}
 
+	// Load env file vars (if specified) and merge with explicit env
+	mergedEnv := make(map[string]string)
+	if envFile != "" {
+		resolvedPath := resolveEnvFilePath(envFile, cwd)
+		fileEnv, err := parseEnvFile(resolvedPath)
+		if err != nil {
+			return ProcessStartResult{
+				Success: false,
+				Error:   fmt.Sprintf("Failed to load env file %q: %s", envFile, err.Error()),
+			}
+		}
+		for k, v := range fileEnv {
+			mergedEnv[k] = v
+		}
+	}
+	// Explicit env overrides file env
+	for k, v := range env {
+		mergedEnv[k] = v
+	}
+
 	processID := uuid.New().String()
-	if err := s.spawnProcess(processID, cwd, command, restartConfig, 0, env); err != nil {
+	if err := s.spawnProcess(processID, cwd, command, restartConfig, 0, mergedEnv); err != nil {
 		return ProcessStartResult{
 			Success: false,
 			Error:   err.Error(),

--- a/backend/process_service_test.go
+++ b/backend/process_service_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -99,7 +100,7 @@ func TestStart_Success(t *testing.T) {
 	svc, _ := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	result := svc.Start(t.TempDir(), "echo hello", nil, nil)
+	result := svc.Start(t.TempDir(), "echo hello", nil, nil, "")
 
 	if !result.Success {
 		t.Fatalf("expected success, got error: %s", result.Error)
@@ -117,7 +118,7 @@ func TestStart_InvalidCwd(t *testing.T) {
 	svc, _ := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	result := svc.Start("/nonexistent/path/that/does/not/exist", "echo hello", nil, nil)
+	result := svc.Start("/nonexistent/path/that/does/not/exist", "echo hello", nil, nil, "")
 
 	if result.Success {
 		t.Fatal("expected failure for non-existent cwd")
@@ -135,7 +136,7 @@ func TestStop_ExistingProcess(t *testing.T) {
 	svc, _ := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	start := svc.Start(t.TempDir(), "sleep 30", nil, nil)
+	start := svc.Start(t.TempDir(), "sleep 30", nil, nil, "")
 	if !start.Success {
 		t.Fatalf("start failed: %s", start.Error)
 	}
@@ -162,7 +163,7 @@ func TestIsRunning_Running(t *testing.T) {
 	svc, _ := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	start := svc.Start(t.TempDir(), "sleep 30", nil, nil)
+	start := svc.Start(t.TempDir(), "sleep 30", nil, nil, "")
 	if !start.Success {
 		t.Fatalf("start failed: %s", start.Error)
 	}
@@ -186,7 +187,7 @@ func TestIsRunning_AfterStop(t *testing.T) {
 	svc, _ := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	start := svc.Start(t.TempDir(), "sleep 30", nil, nil)
+	start := svc.Start(t.TempDir(), "sleep 30", nil, nil, "")
 	if !start.Success {
 		t.Fatalf("start failed: %s", start.Error)
 	}
@@ -206,8 +207,8 @@ func TestBulkStatus(t *testing.T) {
 	t.Cleanup(svc.StopAll)
 
 	dir := t.TempDir()
-	start1 := svc.Start(dir, "sleep 30", nil, nil)
-	start2 := svc.Start(dir, "sleep 30", nil, nil)
+	start1 := svc.Start(dir, "sleep 30", nil, nil, "")
+	start2 := svc.Start(dir, "sleep 30", nil, nil, "")
 	if !start1.Success || !start2.Success {
 		t.Fatal("start failed")
 	}
@@ -230,7 +231,7 @@ func TestGetRunningProcessPids(t *testing.T) {
 	svc, _ := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	start := svc.Start(t.TempDir(), "sleep 30", nil, nil)
+	start := svc.Start(t.TempDir(), "sleep 30", nil, nil, "")
 	if !start.Success {
 		t.Fatalf("start failed: %s", start.Error)
 	}
@@ -258,8 +259,8 @@ func TestStopAll_StopsProcesses(t *testing.T) {
 	svc, _ := newTestProcessService()
 
 	dir := t.TempDir()
-	start1 := svc.Start(dir, "sleep 30", nil, nil)
-	start2 := svc.Start(dir, "sleep 30", nil, nil)
+	start1 := svc.Start(dir, "sleep 30", nil, nil, "")
+	start2 := svc.Start(dir, "sleep 30", nil, nil, "")
 	if !start1.Success || !start2.Success {
 		t.Fatal("start failed")
 	}
@@ -280,7 +281,7 @@ func TestLogBatching_EmitsEvents(t *testing.T) {
 	svc, emitter := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	svc.Start(t.TempDir(), "echo hello", nil, nil)
+	svc.Start(t.TempDir(), "echo hello", nil, nil, "")
 
 	if !emitter.waitForEvent(eventProcessLogBatch) {
 		t.Fatal("expected process-log:batch event to be emitted")
@@ -292,7 +293,7 @@ func TestExitLog_EmittedOnExit(t *testing.T) {
 	svc, emitter := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	svc.Start(t.TempDir(), "echo hello", nil, nil)
+	svc.Start(t.TempDir(), "echo hello", nil, nil, "")
 
 	// Wait for process to exit and logs to flush
 	time.Sleep(500 * time.Millisecond)
@@ -331,7 +332,7 @@ func TestCrashEvent_NonZeroExit(t *testing.T) {
 	svc, emitter := newTestProcessService()
 	t.Cleanup(svc.StopAll)
 
-	svc.Start(t.TempDir(), "sh -c 'exit 1'", nil, nil)
+	svc.Start(t.TempDir(), "sh -c 'exit 1'", nil, nil, "")
 
 	if !emitter.waitForEvent(eventProcessCrash) {
 		t.Fatal("expected process-crash event")
@@ -368,7 +369,7 @@ func TestRestart_TriggeredOnCrash(t *testing.T) {
 		DelayMs:    intPtr(100),
 	}
 
-	svc.Start(t.TempDir(), "sh -c 'exit 1'", restartCfg, nil)
+	svc.Start(t.TempDir(), "sh -c 'exit 1'", restartCfg, nil, "")
 
 	// Wait for crash + restart cycle
 	if !emitter.waitForEvent(eventProcessCrash) {
@@ -409,7 +410,7 @@ func TestRestart_MaxRetriesExceeded(t *testing.T) {
 		DelayMs:    intPtr(10),
 	}
 
-	svc.Start(t.TempDir(), "sh -c 'exit 1'", restartCfg, nil)
+	svc.Start(t.TempDir(), "sh -c 'exit 1'", restartCfg, nil, "")
 
 	// Wait for all retries to exhaust (initial crash + 1 retry + final crash)
 	time.Sleep(1 * time.Second)
@@ -442,7 +443,7 @@ func TestStart_CustomEnvPassedToProcess(t *testing.T) {
 	t.Cleanup(svc.StopAll)
 
 	env := map[string]string{"CLICK_LAUNCH_TEST_VAR": "hello_from_test"}
-	svc.Start(t.TempDir(), "echo $CLICK_LAUNCH_TEST_VAR", nil, env)
+	svc.Start(t.TempDir(), "echo $CLICK_LAUNCH_TEST_VAR", nil, env, "")
 
 	// Wait for process to fully exit (ensures all logs are flushed)
 	if !emitter.waitForLogContaining("exit") {
@@ -481,7 +482,7 @@ func TestStop_CancelsPendingRestart(t *testing.T) {
 		DelayMs:    intPtr(5000), // Long delay so we can cancel
 	}
 
-	start := svc.Start(t.TempDir(), "sh -c 'exit 1'", restartCfg, nil)
+	start := svc.Start(t.TempDir(), "sh -c 'exit 1'", restartCfg, nil, "")
 	if !start.Success {
 		t.Fatalf("start failed: %s", start.Error)
 	}
@@ -500,5 +501,77 @@ func TestStop_CancelsPendingRestart(t *testing.T) {
 	restartCount := emitter.countEvents("process-restart")
 	if restartCount > 0 {
 		t.Fatalf("expected no restart events after stop, got %d", restartCount)
+	}
+}
+
+func TestStartWithEnvFile(t *testing.T) {
+	t.Parallel()
+	svc, emitter := newTestProcessService()
+	t.Cleanup(svc.StopAll)
+
+	cwd, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sample.env has DB_HOST=localhost, APP_ENV=development, etc.
+	result := svc.Start(cwd, "echo $DB_HOST $APP_ENV $OVERRIDE", nil, map[string]string{"OVERRIDE": "custom"}, "sample.env")
+	if !result.Success {
+		t.Fatalf("Start failed: %s", result.Error)
+	}
+
+	if !emitter.waitForLogContaining("exit") {
+		t.Fatal("process did not exit in time")
+	}
+
+	// Verify env file vars were loaded and explicit env overrides work
+	found := false
+	for _, e := range emitter.getEvents() {
+		if e.name != eventProcessLogBatch || len(e.data) == 0 {
+			continue
+		}
+		batch, ok := e.data[0].([]ProcessLogData)
+		if !ok {
+			continue
+		}
+		for _, log := range batch {
+			if log.Type == "stdout" && strings.Contains(log.Output, "localhost") && strings.Contains(log.Output, "development") && strings.Contains(log.Output, "custom") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected stdout to contain env file vars and explicit override")
+	}
+}
+
+func TestStartWithEnvFileMissing(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestProcessService()
+	t.Cleanup(svc.StopAll)
+
+	cwd, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := svc.Start(cwd, "echo hello", nil, nil, "nonexistent.env")
+	if result.Success {
+		t.Fatal("expected Start to fail for missing env file")
+	}
+	if !strings.Contains(result.Error, "env file") {
+		t.Errorf("expected error about env file, got: %s", result.Error)
+	}
+}
+
+func TestStartWithEmptyEnvFile(t *testing.T) {
+	t.Parallel()
+	svc, _ := newTestProcessService()
+	t.Cleanup(svc.StopAll)
+
+	// Empty string means no env file — should work normally
+	result := svc.Start(t.TempDir(), "echo hello", nil, nil, "")
+	if !result.Success {
+		t.Fatalf("Start failed: %s", result.Error)
 	}
 }

--- a/backend/testdata/invalid-env-file-config.yml
+++ b/backend/testdata/invalid-env-file-config.yml
@@ -1,0 +1,10 @@
+project_name: "Test Project"
+
+processes:
+  - name: "Non-string env_file"
+    base_command: "echo hello"
+    env_file: 123
+
+  - name: "Empty env_file"
+    base_command: "echo world"
+    env_file: ""

--- a/backend/testdata/sample.env
+++ b/backend/testdata/sample.env
@@ -1,0 +1,10 @@
+# Database config
+DB_HOST=localhost
+DB_PORT=5432
+
+# App settings
+APP_ENV=development
+# Inline comment lines are skipped
+EMPTY_VALUE=
+QUOTED_VALUE="hello world"
+export EXPORTED_VAR=exported_value

--- a/backend/testdata/valid-env-file-config.yml
+++ b/backend/testdata/valid-env-file-config.yml
@@ -1,0 +1,15 @@
+project_name: "Test Project"
+
+processes:
+  - name: "With env file"
+    base_command: "echo hello"
+    env_file: ".env"
+
+  - name: "With env file and env vars"
+    base_command: "echo world"
+    env_file: "./config/.env.local"
+    env:
+      OVERRIDE: "yes"
+
+  - name: "Without env file"
+    base_command: "echo test"

--- a/backend/types.go
+++ b/backend/types.go
@@ -26,6 +26,7 @@ type ProcessConfig struct {
 	BaseCommand string            `json:"base_command" yaml:"base_command"`
 	Group       *string           `json:"group,omitempty" yaml:"group,omitempty"`
 	Cwd         *string           `json:"cwd,omitempty" yaml:"cwd,omitempty"`
+	EnvFile     *string           `json:"env_file,omitempty" yaml:"env_file,omitempty"`
 	Env         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	Restart     *RestartConfig    `json:"restart,omitempty" yaml:"restart,omitempty"`
 	Args        []ArgConfig       `json:"args,omitempty" yaml:"args,omitempty"`

--- a/example.yml
+++ b/example.yml
@@ -116,3 +116,10 @@ processes:
     group: "Infrastructure"
     base_command: "bash show-cwd.sh"
     cwd: "./resources"
+
+  - name: "Env File Demo"
+    base_command: "bash ./resources/env-demo.sh"
+    env_file: "./resources/example.env"
+    env:
+      VAR2: overridden
+      VAR3: from_explicit_env

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/joho/godotenv v1.5.1
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.74
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jchv/go-winloader v0.0.0-20250406163304-c1995be93bd1 h1:njuLRcjAuMKr7kI3D85AXWkw6/+v9PwtV6M6o11sWHQ=
 github.com/jchv/go-winloader v0.0.0-20250406163304-c1995be93bd1/go.mod h1:alcuEEnZsY1WQsagKhZDsoPCRoOijYqhZvPwLG0kzVs=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=
 github.com/kevinburke/ssh_config v1.6.0/go.mod h1:q2RIzfka+BXARoNexmF9gkxEX7DmvbW9P4hIVx2Kg4M=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=

--- a/resources/env-demo.sh
+++ b/resources/env-demo.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Demonstrates env_file + env precedence:
+# - VAR1 comes from .env file only
+# - VAR2 is in .env file but overridden by explicit env
+# - VAR3 comes from explicit env only
+
+echo "VAR1=$VAR1 (expected: from_env_file)"
+echo "VAR2=$VAR2 (expected: overridden)"
+echo "VAR3=$VAR3 (expected: from_explicit_env)"
+sleep 1

--- a/resources/example.env
+++ b/resources/example.env
@@ -1,0 +1,2 @@
+export VAR1=from_env_file
+VAR2=from_env_file

--- a/src/backend.d.ts
+++ b/src/backend.d.ts
@@ -38,6 +38,7 @@ declare module "@backend" {
       command: string,
       restartConfig: Record<string, any> | null,
       env: Record<string, string>,
+      envFile: string,
     ): Promise<ProcessStartResult>;
     Stop(id: string): Promise<ProcessStopResult>;
     StopAll(): Promise<void>;

--- a/src/features/dashboard/components/ProcessRow.tsx
+++ b/src/features/dashboard/components/ProcessRow.tsx
@@ -104,6 +104,12 @@ export const ProcessRow = (props: ProcessRowProps) => {
                 {envSummary()}
               </div>
             </Show>
+            <Show when={props.process.env_file}>
+              <div class="text-xs text-base-content/60">
+                <span class="font-semibold">Env file:</span>{" "}
+                {props.process.env_file}
+              </div>
+            </Show>
             <Show when={hasOptions()}>{button()}</Show>
           </div>
           <Show when={hasOptions()}>

--- a/src/features/dashboard/hooks/useProcesses.ts
+++ b/src/features/dashboard/hooks/useProcesses.ts
@@ -208,7 +208,14 @@ export const useProcesses = ({
     const storeEnv = processesData[processName]?.envValues;
     const env =
       storeEnv && Object.keys(storeEnv).length > 0 ? { ...storeEnv } : {};
-    const result = await ProcessService.Start(cwd, command, restartConfig, env);
+    const envFile = processConfig.env_file ?? "";
+    const result = await ProcessService.Start(
+      cwd,
+      command,
+      restartConfig,
+      env,
+      envFile,
+    );
 
     if (result.success && result.processId) {
       setProcessesData(processName, {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,6 +31,7 @@ export type YamlConfig = {
     group?: string;
     cwd?: string;
     env?: ProcessEnv;
+    env_file?: string;
     restart?: RestartConfig;
     args?: {
       type: ArgType;


### PR DESCRIPTION
## Summary
- Add `env_file` field to process config: load environment variables from a `.env` file before starting a process
- Variables from env file are merged with explicit `env` values (explicit wins): `env` > `env_file` > system
- Uses `godotenv` for robust `.env` parsing (comments, quotes, `export` prefix, etc.)
- Frontend displays the env file path read-only in the process row
- Includes example "Env File Demo" process demonstrating the 3-tier precedence

## Test plan
- [x] Backend: unit tests for env file parsing (`TestParseEnvFile`, `TestResolveEnvFilePath`)
- [x] Backend: unit tests for `ProcessService.Start` with env file (`TestStartWithEnvFile`, `TestStartWithEnvFileMissing`, `TestStartWithEmptyEnvFile`)
- [x] Backend: config validation tests for valid/invalid `env_file` configs
- [x] All existing tests updated and passing with new `Start` signature
- [x] Manual test: "Env File Demo" in example.yml confirms VAR1 from file, VAR2 overridden, VAR3 from explicit env
- [x] `task check` passes (lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)