### PR TITLE
chore: add env variable expansion demo and setup fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
 git config core.hooksPath .githooks
 bun install --frozen-lockfile
 go mod tidy
+task dev:build
 ```
 
 ## Developer Commands

--- a/example.yml
+++ b/example.yml
@@ -123,3 +123,5 @@ processes:
     env:
       VAR2: overridden
       VAR3: from_explicit_env
+      VAR4: "prefix_$VAR1"
+      VAR5: "prefix_$VAR3"

--- a/resources/env-demo.sh
+++ b/resources/env-demo.sh
@@ -7,4 +7,6 @@
 echo "VAR1=$VAR1 (expected: from_env_file)"
 echo "VAR2=$VAR2 (expected: overridden)"
 echo "VAR3=$VAR3 (expected: from_explicit_env)"
+echo "VAR4=$VAR4 (expected: prefix_\$VAR1 — no expansion)"
+echo "VAR5=$VAR5 (expected: prefix_\$VAR3 — no expansion)"
 sleep 1


### PR DESCRIPTION
## Summary
- Add `VAR4` and `VAR5` to example config env-demo to demonstrate that `$VAR` references in env values are **not expanded** (treated as literal strings)
- Add missing `task dev:build` step to CONTRIBUTING.md setup instructions

## Test plan
- [ ] Run "Env File Demo" process and verify VAR4/VAR5 show literal `$VAR` strings
- [ ] Verify CONTRIBUTING.md setup steps are complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)