### PR TITLE
chore: remove conductor settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,5 +1,0 @@
-"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
-
-[scripts]
-run = "sh scripts/conductor/run.sh"
-setup = "sh scripts/conductor/setup.sh"


### PR DESCRIPTION
## Summary
Remove `.conductor/settings.toml` — no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)